### PR TITLE
Deprecate Ramble 'concretized' flag

### DIFF
--- a/etc/ramble/defaults/spack.yaml
+++ b/etc/ramble/defaults/spack.yaml
@@ -1,4 +1,3 @@
 spack:
-  concretized: false
   packages: {}
   environments: {}

--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -29,7 +29,6 @@ ramble:
                 n_ranks: '1'
                 n_nodes: '1'
   spack:
-    concretized: true
     packages:
       gcc9:
         spack_spec: gcc@9.3.0 target=x86_64

--- a/examples/basic_gromacs_config.yaml
+++ b/examples/basic_gromacs_config.yaml
@@ -38,7 +38,6 @@ ramble:
                 size: '0003'
                 type: 'rf'
   spack:
-    concretized: true
     packages:
       gcc9:
         spack_spec: gcc@9.4.0 target=x86_64

--- a/examples/basic_hostname_config.yaml
+++ b/examples/basic_hostname_config.yaml
@@ -44,6 +44,5 @@ ramble:
                 n_nodes: '1'
                 processes_per_node: '16'
   spack:
-    concretized: true
     packages: {}
     environments: {}

--- a/examples/full_expansion_config.yaml
+++ b/examples/full_expansion_config.yaml
@@ -29,7 +29,6 @@ ramble:
                                 #(part1, 16, openfoam-skx, 2), (part1, 16, openfoam-skx, 4)
                                 #(part2, 32, openfoam-zen2, 2), (part2, 32, openfoam-zen2, 4)
   spack:
-    concretized: true
     packages:
       gcc9:
         spack_spec: gcc@9.3.0 target=x86_64

--- a/examples/vector_gromacs_software_config.yaml
+++ b/examples/vector_gromacs_software_config.yaml
@@ -26,7 +26,6 @@ ramble:
               - n_ranks
               - gromacs_version
   spack:
-    concretized: true
     packages:
       gcc9:
         spack_spec: gcc@9.4.0 target=x86_64

--- a/examples/vector_matrix_gromacs_config.yaml
+++ b/examples/vector_matrix_gromacs_config.yaml
@@ -23,7 +23,6 @@ ramble:
               - type
               - n_ranks
   spack:
-    concretized: true
     packages:
       gcc9:
         spack_spec: gcc@9.4.0 target=x86_64

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -471,7 +471,6 @@ environments created from those packages. Its format is as follows:
 .. code-block:: yaml
 
     spack:
-      concretized: [True/False] # Should be false unless defined in a concretized workspace
       [variables: {}]
       packages:
         <package_name>:

--- a/lib/ramble/docs/tutorials/10_using_modifiers.rst
+++ b/lib/ramble/docs/tutorials/10_using_modifiers.rst
@@ -144,7 +144,6 @@ The resulting configuration file should look like the following.
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -239,7 +238,6 @@ look like the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -309,7 +307,6 @@ configuration file should look like the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/11_using_internals.rst
+++ b/lib/ramble/docs/tutorials/11_using_internals.rst
@@ -138,7 +138,6 @@ the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -245,7 +244,6 @@ configuration file should look like the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -337,7 +335,6 @@ following:
                   variables:
                     n_nodes: [1, 2, 4]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/1_hello_world.rst
+++ b/lib/ramble/docs/tutorials/1_hello_world.rst
@@ -174,7 +174,6 @@ following contents:
                   variables:
                     n_ranks: '1'
       spack:
-        concretized: true
         packages: {}
         environments: {}
 

--- a/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
+++ b/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
@@ -80,7 +80,6 @@ The relevant portion of the workspace configuration file is:
 .. code-block:: YAML
 
     spack:
-      concretized: true
       packages:
         gcc9:
           spack_spec: gcc@9.4.0 target=x86_64

--- a/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
+++ b/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
@@ -223,7 +223,6 @@ look like the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
+++ b/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
@@ -112,7 +112,6 @@ the above section. The result should look like the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -203,7 +202,6 @@ should have the following in your ``ramble.yaml``:
                   - platform_config
                   - n_nodes
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -266,7 +264,6 @@ Your final configuration file should look something like:
                   - platform_config
                   - n_nodes
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
+++ b/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
@@ -95,7 +95,6 @@ final configuration from the previous tutorial.
                   - platform_config
                   - n_nodes
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -193,7 +192,6 @@ generation as well. The result might look like the following:
                   - platform_config
                   - n_nodes
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -264,7 +262,6 @@ into the matrix. The result might look like the following:
                   - n_nodes
                   - mpi_name
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -374,7 +371,6 @@ resulting configuration might look like the following:
                   - n_nodes
                   - mpi_name
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -464,7 +460,6 @@ The resulting configuration file might look like the following:
                   - n_nodes
                   - mpi_name
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/9_success_criteria.rst
+++ b/lib/ramble/docs/tutorials/9_success_criteria.rst
@@ -120,7 +120,6 @@ configuration file might look like the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0
@@ -195,7 +194,6 @@ resulting configuration file might look like the following:
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -65,7 +65,6 @@ Write the following configuration into the file, save, and exit:
                     n_nodes: 1
                     processes_per_node: 30
       spack:
-        concretized: false
         packages: {}
         environments: {}
 
@@ -94,7 +93,6 @@ will look something like this:
                     n_nodes: 1
                     processes_per_node: 30
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.3.0

--- a/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
@@ -45,7 +45,6 @@ final configuration from a previous tutorial.
                   variables:
                     n_nodes: [1, 2]
       spack:
-        concretized: true
         packages:
           gcc9:
             spack_spec: gcc@9.4.0

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -341,7 +341,7 @@ def workspace_remove(args):
 def workspace_concretize_setup_parser(subparser):
     """Concretize a workspace"""
     subparser.add_argument(
-        '-f', '--force_concretize',
+        '-f', '--force-concretize',
         dest='force_concretize',
         action='store_true',
         help='Overwrite software environment configuration with defaults defined in application ' +

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -340,11 +340,20 @@ def workspace_remove(args):
 
 def workspace_concretize_setup_parser(subparser):
     """Concretize a workspace"""
-    pass
+    subparser.add_argument(
+        '-f', '--force_concretize',
+        dest='force_concretize',
+        action='store_true',
+        help='Overwrite software environment configuration with defaults defined in application ' +
+              'definition',
+        required=False)
 
 
 def workspace_concretize(args):
     ws = ramble.cmd.require_active_workspace(cmd_name='workspace concretize')
+
+    if args.force_concretize:
+        ws.force_concretize = True
 
     logger.debug('Concretizing workspace')
     ws.concretize()

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -6,10 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-try:
-    import deprecation
-except ImportError:
-    print('Please use pip to install the requirements.txt')
+import deprecation
 
 import ramble.language.language_base
 import ramble.language.language_helpers

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -118,17 +118,6 @@ class Pipeline(object):
                                    self.workspace.hash_file_name), 'w+') as f:
                 f.write(self.workspace.workspace_hash + '\n')
 
-    def _validate(self):
-        """Perform validation that this pipeline can be executed"""
-        if not self.workspace.is_concretized():
-            error_message = 'Cannot run %s in a ' % self.name + \
-                            'non-conretized workspace\n' + \
-                            'Run `ramble workspace concretize` on this ' + \
-                            'workspace first.\n' + \
-                            'Then ensure its spack configuration is ' + \
-                            'properly configured.'
-            logger.die(error_message)
-
     def _prepare(self):
         """Perform preparation for pipeline execution"""
         pass
@@ -203,7 +192,6 @@ class Pipeline(object):
             )
 
         logger.add_log(self.log_path)
-        self._validate()
         self._prepare()
         self._execute()
         self._complete()

--- a/lib/ramble/ramble/schema/spack.py
+++ b/lib/ramble/ramble/schema/spack.py
@@ -23,7 +23,7 @@ properties = {
         'properties': {
             'concretized': {
                 'type': 'boolean',
-                'default': False
+                'default': None
             },
             'variables': ramble.schema.variables.variables_def,
             'zips': ramble.schema.zips.zips_def,

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -9,8 +9,8 @@
 from enum import Enum
 try:
     import deprecation
-except ImportError:
-    print('Please use pip to install the requirements.txt')
+except ModuleNotFoundError:
+    raise ModuleNotFoundError('Please use pip to install the requirements.txt')
 
 import ramble.repository
 import ramble.workspace

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -413,7 +413,8 @@ class SoftwareEnvironments(object):
     """Class representing a group of software environments"""
 
     _deprecated_sections = [namespace.variables, namespace.zips,
-                            namespace.matrix, namespace.matrices, namespace.exclude]
+                            namespace.matrix, namespace.matrices,
+                            namespace.exclude, 'concretized']
 
     def __init__(self, workspace):
         """SoftwareEnvironments constructor
@@ -485,9 +486,12 @@ class SoftwareEnvironments(object):
             sections_to_print.append('spack:packages:<name>:exclude')
             sections_to_print.append('spack:environments:<name>:exclude')
 
+        if 'concretized' in self._warn_for_deprecation:
+            sections_to_print.append('spack:concretized')
+
         if not hasattr(self, '_warned_deprecated_variables'):
             self._warned_deprecated_variables = True
-            logger.warn('The following config sections are deprecated and ignore:')
+            logger.warn('The following config sections are deprecated and ignored:')
             for section in sections_to_print:
                 logger.warn(f'    {section}')
             logger.warn('Please remove from your configuration files.')

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -7,6 +7,10 @@
 # except according to those terms.
 
 from enum import Enum
+try:
+    import deprecation
+except ImportError:
+    print('Please use pip to install the requirements.txt')
 
 import ramble.repository
 import ramble.workspace
@@ -458,6 +462,10 @@ class SoftwareEnvironments(object):
         """
         return self.info(indent=0)
 
+    @deprecation.deprecated(deprecated_in="0.4.0", removed_in="0.5.0",
+                            current_version=str(ramble.ramble_version),
+                            details="These Spack config sections no longer required and will "
+                                    "be removed from the schema in v0.5.0")
     def _deprecated_warnings(self):
         if not self._warn_for_deprecation or hasattr(self, '_warned_deprecation'):
             return

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -9,10 +9,7 @@
 
 import pytest
 import enum
-try:
-    import deprecation
-except ImportError:
-    print('Please use pip to install the requirements.txt')
+import deprecation
 
 from ramble.appkit import *  # noqa
 

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -9,7 +9,10 @@
 
 import pytest
 import enum
-import deprecation
+try:
+    import deprecation
+except ImportError:
+    print('Please use pip to install the requirements.txt')
 
 from ramble.appkit import *  # noqa
 

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -486,7 +486,6 @@ ramble:
                 n_nodes: '2'
 
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/cmd/on.py
+++ b/lib/ramble/ramble/test/cmd/on.py
@@ -34,9 +34,6 @@ def test_on_command(mutable_mock_workspace_path):
         ramble.test.cmd.workspace.add_basic(ws)
         ramble.test.cmd.workspace.check_basic(ws)
 
-        workspace('concretize')
-        assert ws.is_concretized()
-
         workspace('setup')
         assert os.path.exists(ws.root + '/all_experiments')
 
@@ -58,9 +55,6 @@ def test_execute_pipeline(mutable_mock_workspace_path):
         ramble.test.cmd.workspace.add_basic(ws)
         ramble.test.cmd.workspace.check_basic(ws)
 
-        ws.concretize()
-        assert ws.is_concretized()
-
         setup_pipeline = setup_pipeline_class(ws, filters)
         setup_pipeline.run()
         assert os.path.exists(ws.root + '/all_experiments')
@@ -77,9 +71,6 @@ def test_on_where(mutable_mock_workspace_path):
         ramble.test.cmd.workspace.add_basic(ws)
         ramble.test.cmd.workspace.check_basic(ws)
 
-        workspace('concretize')
-        assert ws.is_concretized()
-
         workspace('setup')
         assert os.path.exists(ws.root + '/all_experiments')
 
@@ -93,9 +84,6 @@ def test_on_executor(mutable_mock_workspace_path):
     with ramble.workspace.read('test') as ws:
         ramble.test.cmd.workspace.add_basic(ws)
         ramble.test.cmd.workspace.check_basic(ws)
-
-        workspace('concretize')
-        assert ws.is_concretized()
 
         workspace('setup')
         assert os.path.exists(ws.root + '/all_experiments')

--- a/lib/ramble/ramble/test/concretize_builtin.py
+++ b/lib/ramble/ramble/test/concretize_builtin.py
@@ -68,7 +68,6 @@ ramble:
               matrix:
               - n_nodes
   spack:
-    concretized: false
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/dry_run_helpers.py
+++ b/lib/ramble/ramble/test/dry_run_helpers.py
@@ -37,7 +37,6 @@ def dry_run_config(section_name, injections, config_path,
     test_dict['spack'] = syaml.syaml_dict()
 
     spack_dict = test_dict['spack']
-    spack_dict['concretized'] = False
     spack_dict['packages'] = syaml.syaml_dict()
     spack_dict['environments'] = syaml.syaml_dict()
 

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -94,7 +94,6 @@ ramble:
               variables:
                 n_nodes: '2'
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@9.3.0 target=x86_64

--- a/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
+++ b/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
@@ -44,7 +44,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/custom_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/custom_executables.py
@@ -82,7 +82,6 @@ ramble:
                   MY_VAR: 'TEST'
                   OTHER_ENV_VAR: 'ANOTHER_TEST'
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -83,7 +83,6 @@ ramble:
               variables:
                 n_nodes: '2'
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@9.3.0 target=x86_64

--- a/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
@@ -52,7 +52,6 @@ ramble:
               variables:
                 n_nodes: '1'
   spack:
-    concretized: true
     packages: {{}}
     environments:
       wrfv4:

--- a/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
@@ -46,7 +46,6 @@ ramble:
                 n_nodes: '1'
                 test_id: [1, 2]
   spack:
-    concretized: true
     packages:
       zlib:
         spack_spec: zlib

--- a/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
@@ -60,7 +60,6 @@ ramble:
                 set:
                   MY_VAR: 'TEST'
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
@@ -42,7 +42,6 @@ ramble:
                 application_workload: ['parallel' ,'serial', 'local']
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
@@ -43,7 +43,6 @@ ramble:
                 n_nodes: 1
                 n_ranks: 1
   spack:
-    concretized: false
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -86,7 +86,6 @@ ramble:
                 where:
                 - '{n_nodes} == 16'
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -61,7 +61,6 @@ ramble:
                 size: '0003'
                 type: 'pme'
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -80,7 +80,6 @@ ramble:
               - environments
               - partitions
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -58,7 +58,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """
@@ -115,7 +114,6 @@ ramble:
                 var_exec_name: 'nothing'
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -42,7 +42,6 @@ ramble:
                 n_nodes: '1'
                 size: '0000.96'
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
@@ -42,7 +42,6 @@ ramble:
                 application_workload: ['parallel' ,'serial', 'local']
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -71,7 +71,6 @@ def test_known_applications(application, capsys):
                 n_nodes: '1'
                 processes_per_node: '1'\n""")
             f.write("""  spack:
-    concretized: false
     packages: {}
     environments: {}\n""")
 

--- a/lib/ramble/ramble/test/end_to_end/merge_config_files.py
+++ b/lib/ramble/ramble/test/end_to_end/merge_config_files.py
@@ -38,7 +38,6 @@ applications:
 
     test_spack = """
 spack:
-  concretized: true
   packages:
     zlib:
       spack_spec: zlib@1.2.12
@@ -56,7 +55,6 @@ ramble:
     n_threads: '1'
   applications: {}
   spack:
-    concretized: false
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
@@ -42,7 +42,6 @@ ramble:
               variables:
                 n_nodes: '8'
   spack:
-    concretized: true
     packages:
       gcc8:
         spack_spec: gcc@8.2.0 target=x86_64

--- a/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
@@ -45,7 +45,6 @@ ramble:
               variables:
                 n_nodes: '1'
   spack:
-    concretized: true
     packages:
       gcc8:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/package_manager_config.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_config.py
@@ -38,7 +38,6 @@ ramble:
             test:
               variables: {}
   spack:
-    concretized: true
     packages:
       zlib:
         spack_spec: 'zlib'

--- a/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
@@ -41,7 +41,6 @@ ramble:
             test:
               variables: {}
   spack:
-    concretized: true
     packages: {}
     environments:
       zlib-configs:
@@ -94,7 +93,6 @@ ramble:
             test:
               variables: {}
   spack:
-    concretized: true
     packages: {}
     environments:
       zlib-configs:

--- a/lib/ramble/ramble/test/end_to_end/passthrough_variables.py
+++ b/lib/ramble/ramble/test/end_to_end/passthrough_variables.py
@@ -46,7 +46,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """
@@ -94,7 +93,6 @@ ramble:
                 mpi_command: '{undefined_var}'
                 n_ranks: '1'
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -78,7 +78,6 @@ ramble:
               - n_nodes
               - env_name
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
@@ -79,7 +79,6 @@ ramble:
               - n_nodes
               - env_name
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/shared_context.py
+++ b/lib/ramble/ramble/test/end_to_end/shared_context.py
@@ -51,7 +51,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/tag_filtering.py
+++ b/lib/ramble/ramble/test/end_to_end/tag_filtering.py
@@ -74,7 +74,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
@@ -53,7 +53,6 @@ ramble:
               variables:
                 n_ranks: "{{{var_name}}}"
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -45,7 +45,6 @@ ramble:
               variables:
                 n_nodes: '1'
   spack:
-    concretized: true
     packages:
       gcc8:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/vector_workloads.py
@@ -42,7 +42,6 @@ ramble:
                 application_workload: ['parallel' ,'serial', 'local']
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -69,7 +69,6 @@ ramble:
               - n_nodes
               - env_name
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/mirror_tests.py
+++ b/lib/ramble/ramble/test/mirror_tests.py
@@ -126,7 +126,6 @@ ramble:
                 n_nodes: '1'
                 processes_per_node: '1'
   spack:
-    concretized: true
     packages: {{}}
     environments: {{}}
 """

--- a/lib/ramble/ramble/test/modifier_application.py
+++ b/lib/ramble/ramble/test/modifier_application.py
@@ -45,7 +45,6 @@ ramble:
               variables:
                 n_nodes: '1'
   spack:
-    concretized: true
     packages:
       gcc:
         spack_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -7,10 +7,7 @@
 # except according to those terms.
 
 import pytest
-try:
-    import deprecation
-except ImportError:
-    print('Please use pip to install the requirements.txt')
+import deprecation
 
 import ramble.workspace
 import ramble.software_environments

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -7,6 +7,10 @@
 # except according to those terms.
 
 import pytest
+try:
+    import deprecation
+except ImportError:
+    print('Please use pip to install the requirements.txt')
 
 import ramble.workspace
 import ramble.software_environments
@@ -427,3 +431,40 @@ def test_compiler_in_environment_warns(request, mutable_mock_workspace_path, cap
 
         assert 'Environment basic contains packages and their compilers' in captured.err
         assert 'Package: basic, Compiler: test_comp' in captured.err
+
+
+@deprecation.fail_if_not_removed
+def test_deprecation_warning(request, mutable_mock_workspace_path, capsys):
+    ws_name = request.node.name
+
+    workspace('create', ws_name)
+
+    assert ws_name in workspace('list')
+
+    with ramble.workspace.read(ws_name) as ws:
+        spack_dict = ws.get_spack_dict()
+
+        spack_dict['concretized'] = True
+
+        spack_dict['packages'] = {}
+        spack_dict['packages']['basic'] = {
+            'spack_spec': 'basic@1.1'
+        }
+        spack_dict['environments'] = {
+            'basic': {
+                'packages': ['basic']
+            }
+        }
+
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        variables = {}
+        env_expander = ramble.expander.Expander(variables, None)
+
+        _ = software_environments.render_environment('basic', env_expander)
+        captured = capsys.readouterr()
+
+        print(captured)
+
+        assert 'The following config sections are deprecated' in captured.err
+        assert 'spack:concretized' in captured.err

--- a/lib/ramble/ramble/test/success_criteria/always_print_foms.py
+++ b/lib/ramble/ramble/test/success_criteria/always_print_foms.py
@@ -43,7 +43,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
@@ -46,7 +46,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/success_criteria/success_functions.py
+++ b/lib/ramble/ramble/test/success_criteria/success_functions.py
@@ -43,7 +43,6 @@ ramble:
               variables:
                 n_nodes: 1
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -48,7 +48,6 @@ ramble:
                 set:
                   MY_VAR: 'TEST'
   spack:
-    concretized: true
     packages:
       zlib:
         spack_spec: zlib

--- a/lib/ramble/ramble/test/workspace_hashing/workspace_name_does_not_change_hash.py
+++ b/lib/ramble/ramble/test/workspace_hashing/workspace_name_does_not_change_hash.py
@@ -46,7 +46,6 @@ ramble:
                 set:
                   MY_VAR: 'TEST'
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
+++ b/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
@@ -47,7 +47,6 @@ ramble:
                 set:
                   MY_VAR: 'TEST'
   spack:
-    concretized: true
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -135,7 +135,6 @@ ramble:
     processes_per_node: -1
   applications: {}
   spack:
-    concretized: false
     packages: {}
     environments: {}
 """
@@ -453,6 +452,7 @@ class Workspace(object):
         self.dry_run = dry_run
         self.always_print_foms = False
         self.repeat_success_strict = True
+        self.force_concretize = False
 
         self.read_default_template = read_default_template
         self.configs = ramble.config.ConfigScope('workspace', self.config_dir)
@@ -859,13 +859,17 @@ class Workspace(object):
     def concretize(self):
         spack_dict = self.get_spack_dict()
 
-        if 'concretized' in spack_dict and spack_dict['concretized']:
-            raise RambleWorkspaceError('Cannot conretize an ' +
-                                       'already concretized ' +
-                                       'workspace')
+        if not self.force_concretize:
+            try:
+                if spack_dict[namespace.packages] or spack_dict[namespace.environments]:
+                    raise RambleWorkspaceError('Cannot concretize an already concretized '
+                                               'workspace. To overwrite the current configuration '
+                                               'with the default software configuration, use '
+                                               '\'ramble workspace concretize -f\'.')
+            except KeyError:
+                pass
 
         spack_dict = syaml.syaml_dict()
-        spack_dict['concretized'] = False
 
         if namespace.packages not in spack_dict or \
                 not spack_dict[namespace.packages]:
@@ -947,7 +951,6 @@ class Workspace(object):
                     if spec_name not in app_packages:
                         app_packages.append(spec_name)
 
-        spack_dict['concretized'] = True
         ramble.config.config.update_config('spack', spack_dict,
                                            scope=self.ws_file_config_scope_name())
 
@@ -1346,13 +1349,6 @@ class Workspace(object):
     def _get_application_dict_config(self, key):
         return self.application_configs[key]['yaml'] if key \
             in self.application_configs else None
-
-    def is_concretized(self):
-        spack_dict = self.get_spack_dict()
-        if 'concretized' in spack_dict:
-            return (True if spack_dict['concretized']
-                    else False)
-        return False
 
     def _get_workspace_section(self, section):
         """Return a dict of a workspace section"""

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -671,7 +671,7 @@ _ramble_workspace_create() {
 }
 
 _ramble_workspace_concretize() {
-    RAMBLE_COMPREPLY="-h --help -f --force_concretize"
+    RAMBLE_COMPREPLY="-h --help -f --force-concretize"
 }
 
 _ramble_workspace_setup() {

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -671,7 +671,7 @@ _ramble_workspace_create() {
 }
 
 _ramble_workspace_concretize() {
-    RAMBLE_COMPREPLY="-h --help"
+    RAMBLE_COMPREPLY="-h --help -f --force_concretize"
 }
 
 _ramble_workspace_setup() {

--- a/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
+++ b/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
@@ -41,7 +41,6 @@ ramble:
                 variables:
                     additional_flags: "-t 120"
 spack:
-  concretized: true
   compilers:
     gcc9:
       spack_spec: gcc@9.3.0


### PR DESCRIPTION
Deprecates 'concretized' flag and config variable and replaces them with 'force_concretize' option to import default software configurations. This simplifies use of Ramble without Spack and helps prepare for support of additional package managers.