### PR TITLE
Fix list nesting in pip package_manager

### DIFF
--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -238,10 +238,10 @@ class Pip(PackageManagerBase):
 
     def environment_load_commands(self):
         self.runner.configure_env(self.app_inst.expander.env_path)
-        return [self.runner.generate_activate_command()]
+        return self.runner.generate_activate_command()
 
     def environment_unload_commands(self):
-        return [self.runner.generate_deactivate_command()]
+        return self.runner.generate_deactivate_command()
 
 
 package_name_regex = re.compile(


### PR DESCRIPTION
Fixes issue where environment_load_commands returned list of lists instead of list of str