### PR TITLE
Add option to only set env-var if unset

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -823,6 +823,7 @@ def environment_variable(
     workloads=None,
     workload_group=None,
     when=None,
+    always_set=True,
     **kwargs,
 ):
     """Define an environment variable to be used in experiments. Workload args
@@ -838,6 +839,8 @@ def environment_variable(
         workload_group (str): Name of app workload group this env-var should be
                                added to
         when (list | None): List of when conditions to apply to directive
+        always_set (bool): Always set this env-var. If false, only set if not
+                           already set.
     """
 
     def _execute_environment_variable(obj):
@@ -846,7 +849,12 @@ def environment_variable(
         )
 
         workload_env_var = ramble.workload.WorkloadEnvironmentVariable(
-            name, value=value, description=description, when=when_list, **kwargs
+            name,
+            value=value,
+            description=description,
+            when=when_list,
+            always_set=always_set,
+            **kwargs,
         )
 
         if workload or workloads or workload_group:

--- a/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
@@ -233,3 +233,50 @@ def test_object_env_var_order(
                     break
 
         assert all(found_order)
+
+
+@pytest.mark.parametrize(
+    "env_var_setting",
+    ["Always", "IfUnset"],
+)
+def test_set_env_var_only_if_unset(workspace_name, mutable_mock_apps_repo, env_var_setting):
+    global_args = ["-w", workspace_name]
+
+    command_str = {
+        "Always": "export SET_ONLY_IF_UNSET=set_value;",
+        "IfUnset": 'export SET_ONLY_IF_UNSET="${SET_ONLY_IF_UNSET:-unset_default}";',
+    }
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            global_args=global_args,
+        )
+
+        config("add", f"variants:test_env_var_set_opt:{env_var_setting}", global_args=global_args)
+
+        ws._re_read()
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "basic",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            assert command_str[env_var_setting] in data

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -158,6 +158,7 @@ class WorkloadEnvironmentVariable:
         value=None,
         description: str = None,
         when=None,
+        always_set=True,
         **kwargs,
     ):
         """WorkloadEnvironmentVariable constructor
@@ -169,7 +170,7 @@ class WorkloadEnvironmentVariable:
             when (list | None): List of when conditions to apply to directive
         """
         self.name = name
-        self.value = value
+        self.value = value if always_set is True else f"${{{name}:-{value}}}"
         self.description = description
         self.when = when.copy() if when else []
 

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -59,3 +59,26 @@ class Basic(ExecutableApplication):
         group_name="test",
         units="s",
     )
+
+    variant(
+        "test_env_var_set_opt",
+        default="Off",
+        values=["Always", "IfUnset", "Off"],
+        description="Test environment variable set option",
+    )
+
+    environment_variable(
+        "SET_ONLY_IF_UNSET",
+        value="unset_default",
+        description="Test environment variable",
+        always_set=False,
+        when=["test_env_var_set_opt=IfUnset"],
+    )
+
+    environment_variable(
+        "SET_ONLY_IF_UNSET",
+        value="set_value",
+        description="Test environment variable",
+        always_set=True,
+        when=["test_env_var_set_opt=Always"],
+    )


### PR DESCRIPTION
Adds an option to only set an environment variable if it is not already set.