### PR TITLE
Evaluate formatted executables in correct order

### DIFF
--- a/lib/ramble/ramble/graphs.py
+++ b/lib/ramble/ramble/graphs.py
@@ -9,12 +9,15 @@
 import enum
 import graphlib
 import itertools
+import re
 from collections import defaultdict
 
 import ramble.error
+import ramble.expander
 import ramble.util.graph
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
+from ramble.workspace import namespace
 
 
 class AttributeGraph:
@@ -449,6 +452,45 @@ class ExecutableGraph(AttributeGraph):
                 f"builtin {builtin_name} matches more than one node ({full_names})"
             )
         return self.node_definitions[full_names[0]]
+
+
+class FormattedExecutableGraph(AttributeGraph):
+    """Graph that handles formatted executables"""
+
+    node_type = "formatted executable"
+
+    def __init__(self, formatted_execs: dict, obj_inst):
+        """Constructs a new FormattedExecutableGraph and evaluates dependencies"""
+        super().__init__(obj_inst)
+        self._formatted_executable_dependencies = defaultdict(list)
+
+        # Define all graph nodes
+        for exec_name, exec_def in formatted_execs.items():
+            exec_node = ramble.util.graph.GraphNode(exec_name, attribute=exec_def)
+            super().add_node(exec_node)
+
+        # Search for internal dependencies and define edges
+        for exec_node in self.node_definitions.values():
+            formatted_conf = exec_node.attribute
+
+            capture_group = r"(\w+)"
+            expansion_pattern = re.compile(
+                rf"{ramble.expander.Expander.expansion_str(capture_group)}"
+            )
+            expansion_strs = set()
+
+            if namespace.prefix in formatted_conf:
+                expansion_strs.update(expansion_pattern.findall(formatted_conf[namespace.prefix]))
+            if namespace.commands in formatted_conf:
+                for line in formatted_conf[namespace.commands]:
+                    expansion_strs.update(expansion_pattern.findall(line))
+            dep_nodes = []
+            for expansion_str in expansion_strs:
+                if expansion_str in self.node_definitions.keys():
+                    dep_node = self.node_definitions[expansion_str]
+                    dep_nodes.append(dep_node)
+
+            super().define_edges(exec_node, dep_nodes)
 
 
 class GraphError(ramble.error.RambleError):

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -273,6 +273,92 @@ ramble:
         assert all(tests)
 
 
+def test_nested_formatted_executables_dependencies_are_evaluated_correctly(workspace_name):
+    test_config = r"""
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '16'
+    n_threads: '1'
+  formatted_executables:
+    level_three:
+      prefix: 'test_l3 '
+      join_separator: '\n'
+      indentation: 2
+      commands:
+      - 'l3line1'
+      - '{level_two}'
+    level_two:
+      prefix: 'test_l2 '
+      join_separator: '\n'
+      indentation: 2
+      commands:
+      - 'l2line1'
+      - 'l2line2'
+      - '{level_one}'
+    level_one:
+      prefix: 'test_l1 '
+      indentation: 2
+      join_separator: '\n'
+      commands:
+      - 'l1line1'
+      - 'l1line2'
+      - 'l1line3'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            simple_test:
+              variables:
+                n_nodes: 1
+  software:
+    packages: {}
+    environments: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, "w+") as f:
+            f.write(test_config)
+
+        with open(os.path.join(ws.config_dir, "execute_experiment.tpl"), "w+") as f:
+            f.write("{level_three}\n")
+            f.write("\n\n    {level_three}\n")
+        ws._re_read()
+
+        workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+
+        experiment_root = ws.experiment_dir
+        exp_dir = os.path.join(experiment_root, "basic", "working_wl", "simple_test")
+        exp_script = os.path.join(exp_dir, "execute_experiment")
+
+        test_regexes = [
+            re.compile(r"^  test_l3 l3line1$"),
+            re.compile(r"^  test_l3   test_l2 l2line1$"),
+            re.compile(r"^  test_l3   test_l2   test_l1 l1line1$"),
+            re.compile(r"^      test_l3 l3line1$"),
+        ]
+
+        tests = [
+            False,
+            False,
+            False,
+            False,
+        ]
+
+        with open(exp_script) as f:
+            for line in f.readlines():
+                for idx, regex in enumerate(test_regexes):
+                    if regex.search(line):
+                        tests[idx] = True
+
+        assert all(tests)
+
+
 def test_formatted_executables_escaped_braces(workspace_name):
     test_config = r"""
 ramble:

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -1574,6 +1574,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             if obj and hasattr(obj, "formatted_executables"):
                 formatted_exec_groups.append(obj.formatted_executables)
 
+        all_execs = {}
+
         for formatted_exec_group in formatted_exec_groups:
             for when_set, formatted_exec_defs in formatted_exec_group.items():
                 if not self.expander.satisfies(
@@ -1588,45 +1590,53 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                             "definition already exists."
                         )
 
-                    n_indentation = 0
-                    if namespace.indentation in formatted_conf:
-                        n_indentation = int(
-                            formatted_conf[namespace.indentation]
+                    if var_name in all_execs:
+                        raise FormattedExecutableError(
+                            f"Formatted executable {var_name} already defined."
                         )
 
-                    prefix = ""
-                    if namespace.prefix in formatted_conf:
-                        prefix = formatted_conf[namespace.prefix]
+                    all_execs[var_name] = formatted_conf
 
-                    join_separator = "\n"
-                    if namespace.join_separator in formatted_conf:
-                        join_separator = formatted_conf[
-                            namespace.join_separator
-                        ].replace(r"\n", "\n")
+        # Set formatted executable dependencies and order
+        formatted_exec_graph = ramble.graphs.FormattedExecutableGraph(
+            all_execs, obj_inst=self
+        )
+        for node in formatted_exec_graph.walk():
+            formatted_conf = node.attribute
 
-                    indentation = " " * n_indentation
+            # Create the formatted command for the executable
+            n_indentation = 0
+            if namespace.indentation in formatted_conf:
+                n_indentation = int(formatted_conf[namespace.indentation])
 
-                    commands_to_format = self._command_list
-                    if namespace.commands in formatted_conf:
-                        commands_to_format = formatted_conf[
-                            namespace.commands
-                        ].copy()
+            prefix = ""
+            if namespace.prefix in formatted_conf:
+                prefix = formatted_conf[namespace.prefix]
 
-                    formatted_lines = []
-                    for command in commands_to_format:
-                        # Do not replace escaped braces here, to allow them to
-                        # be replace properly when templates are written.
-                        expanded = self.expander.expand_var(
-                            command, replace_escaped_braces=False
-                        )
-                        for out_line in expanded.split("\n"):
-                            formatted_lines.append(
-                                indentation + prefix + out_line
-                            )
+            join_separator = "\n"
+            if namespace.join_separator in formatted_conf:
+                join_separator = formatted_conf[
+                    namespace.join_separator
+                ].replace(r"\n", "\n")
 
-                    self.variables[var_name] = join_separator.join(
-                        formatted_lines
-                    )
+            indentation = " " * n_indentation
+
+            commands_to_format = self._command_list
+            if namespace.commands in formatted_conf:
+                commands_to_format = formatted_conf[namespace.commands].copy()
+
+            formatted_lines = []
+            for command in commands_to_format:
+                # Do not replace escaped braces here, to allow them to
+                # be replace properly when templates are written.
+                expanded = self.expander.expand_var(
+                    command, replace_escaped_braces=False
+                )
+
+                for out_line in expanded.split("\n"):
+                    formatted_lines.append(indentation + prefix + out_line)
+
+            self.variables[node.key] = join_separator.join(formatted_lines)
 
     def _derive_variables_for_template_path(self, workspace):
         """Define variables for template paths (for add_expand_vars)"""


### PR DESCRIPTION
Adds a FormattedExecutableGraph to reorder nested formatted executables so that they are evaluated in the correct order regardless of how they are ordered in the YAML.