### PR TITLE
Replace f-strings in logger calls to defer eval

### DIFF
--- a/lib/ramble/ramble/cmd/__init__.py
+++ b/lib/ramble/ramble/cmd/__init__.py
@@ -102,13 +102,13 @@ def get_module(cmd_name):
     require_cmd_name(cmd_name)
     pname = python_name(cmd_name)
 
-    logger.debug(f"Getting module for command {cmd_name}")
+    logger.debug("Getting module for command %s", cmd_name)
 
     try:
         # Try to import the command from the built-in directory
         module_name = f"{__name__}.{pname}"
         module = __import__(module_name, fromlist=[pname, SETUP_PARSER, DESCRIPTION], level=0)
-        logger.debug(f"Imported {pname} from built-in commands")
+        logger.debug("Imported %s from built-in commands", pname)
     except ImportError:
         try:
             module = spack.extensions.get_module(cmd_name)

--- a/lib/ramble/ramble/cmd/clean.py
+++ b/lib/ramble/ramble/cmd/clean.py
@@ -83,12 +83,12 @@ def remove_python_caches():
             for f in files:
                 if f.endswith(".pyc") or f.endswith(".pyo"):
                     fname = os.path.join(root, f)
-                    logger.debug(f"Removing {fname}")
+                    logger.debug("Removing %s", fname)
                     os.remove(fname)
             for d in dirs:
                 if d == "__pycache__":
                     dname = os.path.join(root, d)
-                    logger.debug(f"Removing {dname}")
+                    logger.debug("Removing %s", dname)
                     shutil.rmtree(dname)
 
 
@@ -116,18 +116,18 @@ def remove_reports_files():
                 for inv_file in inventory["files"]:
                     if inv_file in files:
                         fname = os.path.join(root, inv_file)
-                        logger.debug(f"Removing {fname}")
+                        logger.debug("Removing %s", fname)
                         os.remove(fname)
-                logger.debug(f"Removing {inventory_file}")
+                logger.debug("Removing %s", inventory_file)
                 os.remove(inventory_file)
 
             if not os.listdir(root):
-                logger.debug(f"Removing empty directory {root}")
+                logger.debug("Removing empty directory %s", root)
                 os.rmdir(root)
 
         # Clean up symlinks in root dir
         for item in os.listdir(reports_path):
             item_path = os.path.join(reports_path, item)
             if os.path.islink(item_path):
-                logger.debug(f"Removing {item_path}")
+                logger.debug("Removing %s", item_path)
                 os.remove(item_path)

--- a/lib/ramble/ramble/cmd/config.py
+++ b/lib/ramble/ramble/cmd/config.py
@@ -108,7 +108,7 @@ def setup_parser(subparser):
 
 def _get_scope_and_section(args):
     """Extract config scope and section from arguments."""
-    logger.debug(f" Args = {str(args)}")
+    logger.debug(" Args = %s", str(args))
     scope = args.scope
     section = getattr(args, "section", None)
     path = getattr(args, "path", None)

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -212,10 +212,10 @@ def _load_results(args):
         json_results_path = os.path.join(ramble_ws, "results.latest.json")
         yaml_results_path = os.path.join(ramble_ws, "results.latest.yaml")
         if os.path.exists(json_results_path):
-            logger.debug(f"Importing {json_results_path}")
+            logger.debug("Importing %s", json_results_path)
             results_dict = import_results_file(json_results_path)
         elif os.path.exists(yaml_results_path):
-            logger.debug(f"Importing {yaml_results_path}")
+            logger.debug("Importing %s", yaml_results_path)
             results_dict = import_results_file(yaml_results_path)
         else:
             logger.die(

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -77,7 +77,7 @@ def collect_definitions():
                                 definitions[pkg_name] = pkg_def.copy()
                                 used_by[pkg_name] = [obj_namespace]
                             else:
-                                logger.debug(f" Checking package: {pkg_name}")
+                                logger.debug(" Checking package: %s", pkg_name)
                                 if pkg_def.conflict_spec(
                                     definitions[pkg_name], skip_conflicting_when=True
                                 ):

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -381,7 +381,7 @@ def workspace_remove(args):
         workspace = ramble.workspace.read(workspace_name)
         read_workspaces.append(workspace)
 
-    logger.debug(f"Removal args: {args}")
+    logger.debug("Removal args: %s", args)
 
     if not args.yes_to_all:
         answer = tty.get_yes_or_no(
@@ -1113,7 +1113,7 @@ def workspace_edit(args, unknown_args):
     else:
         try:
             if unknown_args:
-                logger.debug(f"Passing {unknown_args} to editor...")
+                logger.debug("Passing %s to editor...", unknown_args)
             edit_files += unknown_args or []
             editor(*edit_files)
         except TypeError:

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -1023,7 +1023,7 @@ def read_config_file(filename, schema=None):
         raise ConfigFileError(f"Config file is not readable: {filename}")
 
     try:
-        logger.debug(f"Reading config file {filename}")
+        logger.debug("Reading config file %s", filename)
         with open(filename) as f:
             data = syaml.load_config(f)
 

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -370,7 +370,7 @@ class ExpansionNode:
                 try:
                     old_value = self.value
                     self.value = evaluation_func(self.value)
-                    logger.debug(f"  Expanded: {old_value} -> {self.value}")
+                    logger.debug("  Expanded: %s -> %s", old_value, self.value)
                     if old_value != self.value:
                         required_passthrough = False
                 except SyntaxError:
@@ -759,9 +759,9 @@ class Expander:
         if ramble.config.get("config:disable_passthrough"):
             passthrough_setting = False
 
-        logger.debug(f"BEGINNING OF EXPAND_VAR STACK ON {var}")
-        logger.debug(f" REPLACE VAR (1): {replace_escaped_braces}")
-        logger.debug(f" REPLACE VAR (2): {self._replace_escaped_braces}")
+        logger.debug("BEGINNING OF EXPAND_VAR STACK ON %s", var)
+        logger.debug(" REPLACE VAR (1): %s", replace_escaped_braces)
+        logger.debug(" REPLACE VAR (2): %s", self._replace_escaped_braces)
 
         if extra_vars:
             expansions = collections.ChainMap(extra_vars, self._variables)
@@ -785,12 +785,12 @@ class Expander:
                     "context."
                 ) from None
 
-        logger.debug(f"END OF EXPAND_VAR STACK {value}")
+        logger.debug("END OF EXPAND_VAR STACK %s", value)
         if typed:
-            logger.debug(f"BEGINNING OF TYPING ON {value}")
+            logger.debug("BEGINNING OF TYPING ON %s", value)
             try:
                 value = ast.literal_eval(value)
-                logger.debug(f"END OF TYPING {value}")
+                logger.debug("END OF TYPING %s", value)
             except ValueError:
                 logger.debug("END OF TYPING Failed with ValueError")
             except SyntaxError:
@@ -986,12 +986,12 @@ class Expander:
 
                     return out_str
                 except MathEvaluationError as e:
-                    logger.debug(f'   Math input is: "{in_str}"')
+                    logger.debug('   Math input is: "%s"', in_str)
                     logger.debug(e)
                 except RambleSyntaxError as e:
                     raise RambleSyntaxError(f'{str(e)} in "{in_str}"') from None
                 except SyntaxError as e:
-                    logger.debug(f"ast.parse hit the following syntax error on input: {in_str}")
+                    logger.debug("ast.parse hit the following syntax error on input: %s", in_str)
                     logger.debug(e)
 
                 for warn in wal:
@@ -1339,8 +1339,8 @@ class Expander:
 def raise_passthrough_error(in_str, out_str):
     """Raise an error when passthrough is disabled but variables are not all expanded"""
 
-    logger.debug(f"Expansion stack errors: attempted to expand " f'"{in_str}"')
-    logger.debug(f"  As: {out_str}")
+    logger.debug('Expansion stack errors: attempted to expand "%s"', in_str)
+    logger.debug("  As: %s", out_str)
     raise RamblePassthroughError("Error Stack:\n" f'Input: "{in_str}"\n' f'Output: "{out_str}"\n')
 
 

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -76,7 +76,7 @@ class ExperimentResult:
         experiment_dir = app_inst.expander.experiment_run_dir
         cache_file = os.path.join(experiment_dir, self.cache_file_name)
 
-        logger.debug(f"Experiment results cache file is: {cache_file}")
+        logger.debug("Experiment results cache file is: %s", cache_file)
 
         if not os.path.isfile(cache_file):
             logger.debug("No valid experiment results cache found. Will create one.")

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -606,7 +606,7 @@ class ExperimentSet:
 
         # The results are now processed serially to update the experiment set state
         for app_inst, final_exp_namespace, is_base_experiment in all_processed_experiments:
-            logger.debug(f"   Final name: {final_exp_namespace}")
+            logger.debug("   Final name: %s", final_exp_namespace)
 
             if final_exp_namespace in rendered_experiments:
                 left_vars = self.experiments[final_exp_namespace].variables

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -320,7 +320,7 @@ class URLFetchStrategy(FetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            logger.debug(f"Already downloaded {self.archive_file}")
+            logger.debug("Already downloaded %s", self.archive_file)
             return
 
         url = None
@@ -344,7 +344,7 @@ class URLFetchStrategy(FetchStrategy):
             raise FailedDownloadError(url)
 
     def _existing_url(self, url):
-        logger.debug(f"Checking existence of {url}")
+        logger.debug("Checking existence of %s", url)
 
         if ramble.config.get("config:url_fetch_method") == "curl":
             curl = self.curl
@@ -524,7 +524,7 @@ class URLFetchStrategy(FetchStrategy):
             shutil.move(self.archive_file, dest)
             return
 
-        logger.debug(f"Staging archive: {self.archive_file}")
+        logger.debug("Staging archive: %s", self.archive_file)
 
         if not self.archive_file:
             raise NoArchiveFileError(
@@ -535,7 +535,7 @@ class URLFetchStrategy(FetchStrategy):
             self.extension = extension(self.archive_file)
 
         if self.stage.expanded:
-            logger.debug(f"Source already staged to {self.stage.source_path}")
+            logger.debug("Source already staged to %s", self.stage.source_path)
             return
 
         decompress = decompressor_for(self.archive_file, self.extension)
@@ -699,11 +699,11 @@ class VCSFetchStrategy(FetchStrategy):
 
     @_needs_stage
     def check(self):
-        logger.debug(f"No checksum needed when fetching with {self.url_attr}")
+        logger.debug("No checksum needed when fetching with %s", self.url_attr)
 
     @_needs_stage
     def expand(self):
-        logger.debug(f"Source fetched with {self.url_attr} is already expanded.")
+        logger.debug("Source fetched with %s is already expanded.", self.url_attr)
 
     @_needs_stage
     def archive(self, destination, **kwargs):
@@ -847,7 +847,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            logger.debug(f"Already fetched {self.stage.source_path}")
+            logger.debug("Already fetched %s", self.stage.source_path)
             return
 
         self.clone(commit=self.commit, branch=self.branch, tag=self.tag)
@@ -869,7 +869,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         """
         # Default to spack source path
         dest = dest or self.stage.source_path
-        logger.debug(f"Cloning git repository: {self._repo_info()}")
+        logger.debug("Cloning git repository: %s", self._repo_info())
 
         git = self.git
         debug = ramble.config.get("config:debug")
@@ -1163,10 +1163,10 @@ class SvnFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            logger.debug(f"Already fetched {self.stage.source_path}")
+            logger.debug("Already fetched %s", self.stage.source_path)
             return
 
-        logger.debug(f"Checking out subversion repository: {self.url}")
+        logger.debug("Checking out subversion repository: %s", self.url)
 
         args = ["checkout", "--force", "--quiet"]
         if self.revision:
@@ -1273,13 +1273,13 @@ class HgFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            logger.debug(f"Already fetched {self.stage.source_path}")
+            logger.debug("Already fetched %s", self.stage.source_path)
             return
 
         args = []
         if self.revision:
             args.append(f"at revision {self.revision}")
-        logger.debug(f"Cloning mercurial repository: {self.url} {args}")
+        logger.debug("Cloning mercurial repository: %s %s", self.url, args)
 
         args = ["clone"]
 
@@ -1335,14 +1335,14 @@ class S3FetchStrategy(URLFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            logger.debug(f"Already downloaded {self.archive_file}")
+            logger.debug("Already downloaded %s", self.archive_file)
             return
 
         parsed_url = url_util.parse(self.url)
         if parsed_url.scheme != "s3":
             raise FetchError("S3FetchStrategy can only fetch from s3:// urls.")
 
-        logger.debug(f"Fetching {self.url}")
+        logger.debug("Fetching %s", self.url)
 
         basename = os.path.basename(parsed_url.path)
 
@@ -1382,14 +1382,14 @@ class GCSFetchStrategy(URLFetchStrategy):
         import ramble.util.web as web_util
 
         if self.archive_file:
-            logger.debug(f"Already downloaded {self.archive_file}")
+            logger.debug("Already downloaded %s", self.archive_file)
             return
 
         parsed_url = url_util.parse(self.url)
         if parsed_url.scheme != "gs":
             raise FetchError("GCSFetchStrategy can only fetch from gs:// urls.")
 
-        logger.debug(f"Fetching {self.url}")
+        logger.debug("Fetching %s", self.url)
 
         basename = os.path.basename(parsed_url.path)
 

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -451,7 +451,7 @@ class ArchivePipeline(Pipeline):
 
             create_symlink(tar_path, tar_path_latest)
 
-            logger.debug(f"Archive url: {archive_url}")
+            logger.debug("Archive url: %s", archive_url)
 
             if archive_url:
                 # Perform Upload
@@ -580,10 +580,10 @@ class ExecutePipeline(Pipeline):
 
         for _, app_inst, _ in self._experiment_set.filtered_experiments(self.filters):
             if app_inst.is_template:
-                logger.debug(f"{app_inst.name} is a template. Skipping execution.")
+                logger.debug("%s is a template. Skipping execution.", app_inst.name)
                 continue
             if app_inst.repeats.is_repeat_base:
-                logger.debug(f"{app_inst.name} is a repeat base. Skipping execution.")
+                logger.debug("%s is a repeat base. Skipping execution.", app_inst.name)
                 continue
 
             app_inst.define_variables_for_template_path(self.workspace)

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -432,7 +432,7 @@ class Renderer:
         where_expander = ramble.expander.Expander(object_variables, None)
 
         for obj in new_objects:
-            logger.debug(f"Rendering {render_group.object}:")
+            logger.debug("Rendering %s:", render_group.object)
 
             keep_object = True
             if exclude_where:

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -154,13 +154,13 @@ def filter_exp_results(experiments: list):
 
     for exp in experiments:
         if exp["name"] in skip_exps or is_repeat_child(exp):
-            logger.debug(f"Skipping import of experiment {exp['name']}")
+            logger.debug("Skipping import of experiment %s", exp["name"])
             continue
 
         elif exp["RAMBLE_STATUS"] != "SUCCESS":
             continue
         else:
-            logger.debug(f"Importing experiment {exp['name']}")
+            logger.debug("Importing experiment %s", exp["name"])
             # For repeat experiments, use summary stats from base exp and skip repeats
             # Repeats are sequenced after base exp
 
@@ -366,7 +366,9 @@ def extract_data(experiments: List[dict], foms: List[str], variables: List[str],
                                 elif var in _ADDITIONAL_VARS:
                                     continue
                                 else:
-                                    logger.debug(f"{var} not found in the results data. Skipping.")
+                                    logger.debug(
+                                        "%s not found in the results data. Skipping.", var
+                                    )
 
                     extracted_data.append(exp_data)
 
@@ -375,7 +377,7 @@ def extract_data(experiments: List[dict], foms: List[str], variables: List[str],
 
     # Apply where to down select
     if where_query:
-        logger.info(f"Applying where query: {where_query}")
+        logger.info("Applying where query: %s", where_query)
         extracted_df = extracted_df.query(where_query)
 
     return extracted_df
@@ -511,7 +513,7 @@ class PlotGenerator:
             f"{perf_measure} vs {scale_var} for {series}"
             f"{get_direction_suffix(self.better_direction)}"
         )
-        logger.debug(f"Generating plot for {title}")
+        logger.debug("Generating plot for %s", title)
 
         # TODO: prep_draw method in subclass ScalingPlotGenerator, not this class
         fig, ax = self.prep_draw(perf_measure, scale_var)
@@ -578,7 +580,7 @@ class PlotGenerator:
         # FIXME: DRY THIS
         """Draws a filler figure in cases where a chart cannot be drawn due to errors."""
         title = f"{perf_measure} vs {scale_var} for {series}"
-        logger.debug(f"Generating filler figure for {title}")
+        logger.debug("Generating filler figure for %s", title)
 
         fig, ax = plt.subplots(figsize=self.figsize)
         fig.text(
@@ -704,7 +706,7 @@ class ScalingPlotGenerator(PlotGenerator):
             )
             return selected_data
 
-        logger.debug(f"Normalizing data (by {first_perf_value})")
+        logger.debug("Normalizing data (by %s)", first_perf_value)
 
         selected_data.loc[:, ReportVars.IDEAL_PERF_VALUE.value] = first_perf_value
 
@@ -985,7 +987,7 @@ class MultiLinePlot(ScalingPlotGenerator):
     def draw_multiline(self, perf_measure, scale_var, pdf_report, y_label):
         # TODO: add suffix 'higher/lower is better' to chart title based on better_direction
         title = f"{perf_measure} vs {scale_var}"
-        logger.debug(f"Generating plot for {title}")
+        logger.debug("Generating plot for %s", title)
 
         # TODO: prep_draw method in subclass ScalingPlotGenerator, not this class
         fig, ax = self.prep_draw(perf_measure, scale_var)

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -856,7 +856,7 @@ class RepoPath:
         """Given a spec, get the repository for its object."""
         # We don't @_autospec this function b/c it's called very frequently
         # and we want to avoid parsing str's into Specs unnecessarily.
-        logger.debug(f"Getting repo for obj {spec}")
+        logger.debug("Getting repo for obj %s", spec)
         namespace = None
         if isinstance(spec, ramble.spec.Spec):
             namespace = spec.namespace
@@ -865,7 +865,7 @@ class RepoPath:
             # handle strings directly for speed instead of @_autospec'ing
             namespace, _, name = spec.rpartition(".")
 
-        logger.debug(f" Name and namespace = {namespace} - {name}")
+        logger.debug(" Name and namespace = %s - %s", namespace, name)
         # If the spec already has a namespace, then return the
         # corresponding repo if we know about it.
         if namespace:
@@ -1161,7 +1161,7 @@ class Repo:
         # it actually exists, because we have to load it anyway, and that ends
         # up checking for existence. We avoid constructing
         # FastObjectChecker, which will stat all objects.
-        logger.debug(f"Getting obj {spec} from repo")
+        logger.debug("Getting obj %s from repo", spec)
         if spec.name is None:
             raise UnknownObjectError(None, self)
 
@@ -1359,7 +1359,7 @@ class Repo:
             )
 
         class_name = nm.mod_to_class(obj_name)
-        logger.debug(f" Class name = {class_name}")
+        logger.debug(" Class name = %s", class_name)
         module = self._get_obj_module(obj_name)
 
         cls = getattr(module, class_name)

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -990,8 +990,8 @@ class SoftwareEnvironments:
             if isinstance(pkg, RenderedPackage) and pkg.compiler and pkg.compiler in pkg_names:
                 compiler_warnings.append((pkg.name, pkg.compiler))
 
-        logger.debug(f" Used compilers: {used_compilers}")
-        logger.debug(f" Compiler warnings: {compiler_warnings}")
+        logger.debug(" Used compilers: %s", used_compilers)
+        logger.debug(" Compiler warnings: %s", compiler_warnings)
         if compiler_warnings:
             logger.warn(
                 f"Environment {environment.name} contains packages and their "

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -123,7 +123,7 @@ def _first_accessible_path(paths):
                 return path
 
         except OSError as e:
-            logger.debug(f"OSError while checking stage path {path}: {e}")
+            logger.debug("OSError while checking stage path %s: %s", path, e)
 
     return None
 
@@ -284,7 +284,7 @@ class InputStage:
                 lock_id = prefix_bits(sha1, bit_length(sys.maxsize))
                 stage_lock_path = os.path.join(self.path, ".lock")
 
-                logger.debug(f"Creating stage lock {self.name}")
+                logger.debug("Creating stage lock %s", self.name)
                 InputStage.stage_locks[self.name] = ramble.util.lock.Lock(
                     stage_lock_path, lock_id, 1, desc=self.name
                 )
@@ -514,14 +514,14 @@ class InputStage:
         absolute_storage_path = os.path.join(mirror.root, self.mirror_paths.storage_path)
 
         if os.path.exists(absolute_storage_path):
-            logger.debug(f"Already existed: {absolute_storage_path}")
+            logger.debug("Already existed: %s", absolute_storage_path)
             stats.already_existed(absolute_storage_path)
-            logger.debug(f"   Stats? {stats.present}")
+            logger.debug("   Stats? %s", stats.present)
         else:
             self.fetch()
             self.check()
             mirror.store(self.fetcher, self.mirror_paths.storage_path)
-            logger.debug(f"Added: {absolute_storage_path}")
+            logger.debug("Added: %s", absolute_storage_path)
             stats.added(absolute_storage_path)
 
         if not os.path.exists(absolute_storage_path):
@@ -535,9 +535,9 @@ class InputStage:
         downloaded."""
         if not self.expanded:
             self.fetcher.expand()
-            logger.debug(f"Created stage in {self.path}")
+            logger.debug("Created stage in %s", self.path)
         else:
-            logger.debug(f"Already staged {self.name} in {self.path}")
+            logger.debug("Already staged %s in %s", self.name, self.path)
 
     def restage(self):
         """Removes the expanded archive path if it exists, then re-expands
@@ -728,7 +728,7 @@ class DIYStage:
         logger.debug("No checksum needed for DIY.")
 
     def expand_archive(self):
-        logger.debug(f"Using source directory: {self.source_path}")
+        logger.debug("Using source directory: %s", self.source_path)
 
     @property
     def expanded(self):

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -71,10 +71,10 @@ class ScopedCriteriaList:
         self.validate_scope(scope)
 
         for s in self._flush_scopes[scope]:
-            logger.debug(f" Flushing scope: {s}")
+            logger.debug(" Flushing scope: %s", s)
             logger.debug("    It contained:")
             for crit in self.criteria[s]:
-                logger.debug(f"      {crit.name}")
+                logger.debug("      %s", crit.name)
             del self.criteria[s]
             self.criteria[s] = []
 
@@ -163,7 +163,7 @@ class SuccessCriteria:
             self.fom_context = fom_context
 
     def passed(self, test=None, app_inst=None, fom_values=None):
-        logger.debug(f"Testing criteria {self.name} mode = {self.mode}")
+        logger.debug("Testing criteria %s mode = %s", self.name, self.mode)
         if self.mode == "string":
             if self.match is not None:
                 match_obj = self.match.match(test)
@@ -227,7 +227,7 @@ class SuccessCriteria:
         return False
 
     def anti_matched(self, test=None):
-        logger.debug(f"Testing anti-criterion {self.name} mode = {self.mode}")
+        logger.debug("Testing anti-criterion %s mode = %s", self.name, self.mode)
         if self.mode == "string":
             if self.anti_match is not None:
                 anti_match_obj = self.anti_match.match(test)
@@ -236,11 +236,11 @@ class SuccessCriteria:
         return False
 
     def mark_found(self):
-        logger.debug(f"   {self.name} was matched!")
+        logger.debug("   %s was matched!", self.name)
         self.found = True
 
     def mark_anti_found(self):
-        logger.debug(f"   {self.name} was anti-matched!")
+        logger.debug("   %s was anti-matched!", self.name)
         self.anti_found = True
 
     def reset(self):

--- a/lib/ramble/ramble/uploader.py
+++ b/lib/ramble/ramble/uploader.py
@@ -45,7 +45,7 @@ def validate_data(data, schema):
     try:
         jsonschema.validate(instance=data, schema=schema)
     except jsonschema.exceptions.ValidationError as err:
-        logger.error(f"Schema validation error: {err}")
+        logger.error("Schema validation error: %s", err)
         raise
 
 
@@ -512,7 +512,7 @@ class BigQueryUploader(Uploader):
         try:
             client.get_dataset(uri)
         except NotFound:
-            logger.info(f"Dataset {uri} is not found, creating it.")
+            logger.info("Dataset %s is not found, creating it.", uri)
             client.create_dataset(uri)
 
         # Check schema version
@@ -540,13 +540,15 @@ class BigQueryUploader(Uploader):
             table_id = f"{uri}.{table_def['table']}"
             try:
                 client.get_table(table_id)
-                logger.info(f"Table {table_id} already exists.")
+                logger.info("Table %s already exists.", table_id)
             except NotFound:
-                logger.info(f"Creating table {table_id}")
+                logger.info("Creating table %s", table_id)
                 bq_schema = self._schema_to_bigquery(table_def["schema"][table_def["version"]])
                 table = bigquery.Table(table_id, schema=bq_schema)
                 table = client.create_table(table)
-                logger.info(f"Created table {table.project}.{table.dataset_id}.{table.table_id}")
+                logger.info(
+                    "Created table %s.%s.%s", table.project, table.dataset_id, table.table_id
+                )
                 tables_created = True
 
         if tables_created:
@@ -572,16 +574,16 @@ class BigQueryUploader(Uploader):
         if rows_per_batch <= 1:
             rows_per_batch = 1
 
-        logger.debug(f"Size: {sys.getsizeof(json.dumps(data))}B")
-        logger.debug(f"Length in rows: {data_len}")
-        logger.debug(f"Num Batches: {approx_num_batches}")
-        logger.debug(f"Rows per Batch: {rows_per_batch}")
+        logger.debug("Size: %sB", sys.getsizeof(json.dumps(data)))
+        logger.debug("Length in rows: %s", data_len)
+        logger.debug("Num Batches: %s", approx_num_batches)
+        logger.debug("Rows per Batch: %s", rows_per_batch)
 
         for i in range(0, data_len, rows_per_batch):
             end = i + rows_per_batch
             if end > data_len:
                 end = data_len
-            logger.debug(f"Uploading rows {i} to {end}")
+            logger.debug("Uploading rows %s to %s", i, end)
             table_name = table_id.split(".")[-1]
             table_def = next((t for t in self.schema if t["table"] == table_name), None)
             if table_def and table_def["schema"].get(table_def["version"]):
@@ -636,24 +638,26 @@ class PrintOnlyUploader(Uploader):
             software_to_insert,
         ) = _prepare_data(results, uri)
         logger.info("NOTE: The PrintOnly uploader only logs, but does not upload any data.")
-        logger.info(f"{len(exps_to_insert)} experiment(s) would be uploaded to {exp_table_id}:")
+        logger.info("%s experiment(s) would be uploaded to %s:", len(exps_to_insert), exp_table_id)
         for exp in exps_to_insert:
-            logger.info(f"  {exp}")
-        logger.info(f"{len(foms_to_insert)} fom(s) would be uploaded to {fom_table_id}:")
+            logger.info("  %s", exp)
+        logger.info("%s fom(s) would be uploaded to %s:", len(foms_to_insert), fom_table_id)
         for fom in foms_to_insert:
-            logger.info(f"  {fom}")
+            logger.info("  %s", fom)
         logger.info(
-            f"{len(metadata_to_insert)} experiment metadata item(s) "
-            f"would be uploaded to {metadata_table_id}:"
+            "%s experiment metadata item(s) would be uploaded to %s:",
+            len(metadata_to_insert),
+            metadata_table_id,
         )
         for metadata_item in metadata_to_insert:
-            logger.info(f"  {metadata_item}")
+            logger.info("  %s", metadata_item)
         logger.info(
-            f"{len(software_to_insert)} "
-            f"software package(s) would be uploaded to {software_table_id}:"
+            "%s software package(s) would be uploaded to %s:",
+            len(software_to_insert),
+            software_table_id,
         )
         for software in software_to_insert:
-            logger.info(f"  {software}")
+            logger.info("  %s", software)
 
 
 class SQLiteUploader(Uploader):
@@ -725,9 +729,9 @@ class SQLiteUploader(Uploader):
                     f"type='table' AND name='{table_name}'"
                 )
                 if cursor.fetchone()[0] == 1:
-                    logger.info(f"Table {table_name} already exists.")
+                    logger.info("Table %s already exists.", table_name)
                 else:
-                    logger.info(f"Creating table {table_name}")
+                    logger.info("Creating table %s", table_name)
                     sqlite_schema = self._schema_to_sqlite(
                         table_def["schema"][table_def["version"]]
                     )

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -129,6 +129,18 @@ class Logger:
 
         return kwargs
 
+    def _format_args(self, args):
+        """Format arguments if the first argument is a string and there are more arguments.
+
+        Uses % formatting if possible. Fallback to original args if TypeError occurs.
+        """
+        if len(args) > 1 and isinstance(args[0], str):
+            try:
+                return (args[0] % args[1:],)
+            except TypeError:
+                return args
+        return args
+
     @contextmanager
     def configure_colors(self, **kwargs):
         old_value = color.get_color_when()
@@ -144,12 +156,13 @@ class Logger:
         print). Perform this action for all logs and the default log (to
         screen).
         """
+        formatted_args = self._format_args(args)
         for idx, _ in enumerate(self.log_stack):
             st_kwargs = self._stream_kwargs(default_kwargs=kwargs, index=idx)
             with self.configure_colors(**st_kwargs):
-                tty.info(*args, **st_kwargs)
+                tty.info(*formatted_args, **st_kwargs)
 
-        tty.msg(*args, **kwargs)
+        tty.msg(*formatted_args, **kwargs)
 
     def msg(self, *args, **kwargs):
         """Print a message to the active log
@@ -157,9 +170,10 @@ class Logger:
         Pass all args and kwargs to tty.info (which will concatenate and
         print). Perform this action for the active log only.
         """
+        formatted_args = self._format_args(args)
         st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
         with self.configure_colors(**st_kwargs):
-            tty.info(*args, **st_kwargs)
+            tty.info(*formatted_args, **st_kwargs)
 
     def info(self, *args, **kwargs):
         """Print a message to the active log
@@ -167,9 +181,10 @@ class Logger:
         Pass all args and kwargs to tty.info (which will concatenate and
         print). Perform this action for the active log only.
         """
+        formatted_args = self._format_args(args)
         st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
         with self.configure_colors(**st_kwargs):
-            tty.info(*args, **st_kwargs)
+            tty.info(*formatted_args, **st_kwargs)
 
     def verbose(self, *args, **kwargs):
         """Print a verbose message to the active log
@@ -177,9 +192,10 @@ class Logger:
         Pass all args and kwargs to tty.verbose (which will concatenate and
         print). Perform this action for the active log only.
         """
+        formatted_args = self._format_args(args)
         st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
         with self.configure_colors(**st_kwargs):
-            tty.verbose(*args, **st_kwargs)
+            tty.verbose(*formatted_args, **st_kwargs)
 
     def warn(self, *args, **kwargs):
         """Print a warning message to the active log
@@ -187,23 +203,23 @@ class Logger:
         Pass all args and kwargs to tty.warn (which will concatenate and
         print). Perform this action for the active log only.
         """
-
+        formatted_args = self._format_args(args)
         st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
         if self._aggregated_warnings:
             if "stream" in st_kwargs:
                 file_name = st_kwargs["stream"].name
                 if file_name not in self.file_warnings:
                     self.file_warnings[file_name] = []
-                self.file_warnings[file_name].append((args, kwargs))
+                self.file_warnings[file_name].append((formatted_args, kwargs))
             else:
-                self.global_warnings.append((args, kwargs))
+                self.global_warnings.append((formatted_args, kwargs))
 
         else:
             if "stream" in st_kwargs:
                 with self.configure_colors(**st_kwargs):
-                    tty.warn(*args, **st_kwargs)
+                    tty.warn(*formatted_args, **st_kwargs)
 
-            tty.warn(*args, **kwargs)
+            tty.warn(*formatted_args, **kwargs)
 
     def all_warnings(self):
         """Print all warnings that have been encountered
@@ -235,9 +251,10 @@ class Logger:
         print). Perform this action for the active log only.
         """
         if tty._debug:
+            formatted_args = self._format_args(args)
             st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
             with self.configure_colors(**st_kwargs):
-                tty.debug(*args, **st_kwargs)
+                tty.debug(*formatted_args, **st_kwargs)
 
     def error(self, *args, **kwargs):
         """Print an error message
@@ -246,12 +263,13 @@ class Logger:
         print). Perform this action all logs, and the default stream (print to
         screen).
         """
+        formatted_args = self._format_args(args)
         for idx, _ in enumerate(self.log_stack):
             st_kwargs = self._stream_kwargs(index=idx, default_kwargs=kwargs)
             with self.configure_colors(**st_kwargs):
-                tty.error(*args, **st_kwargs)
+                tty.error(*formatted_args, **st_kwargs)
 
-        tty.error(*args, **kwargs)
+        tty.error(*formatted_args, **kwargs)
 
     def die(self, *args, **kwargs):
         """Print an error message and terminate execution
@@ -260,15 +278,16 @@ class Logger:
         print). Perform this action all logs. After all logs are printed to,
         terminate execution (and error) using tty.die.
         """
+        formatted_args = self._format_args(args)
         for idx, _ in enumerate(self.log_stack):
             st_kwargs = self._stream_kwargs(index=idx, default_kwargs=kwargs)
             with self.configure_colors(**st_kwargs):
-                tty.error(*args, **st_kwargs)
+                tty.error(*formatted_args, **st_kwargs)
 
         while self.log_stack:
             self.remove_log()
 
-        tty.die(*args, **kwargs)
+        tty.die(*formatted_args, **kwargs)
 
 
 logger = Logger()

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -148,7 +148,7 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
             remote_path = "file://" + remote_path
     remote_url = url_util.parse(remote_path)
     remote_file_path = url_util.local_file_path(remote_url)
-    logger.debug(f"Trying to backup file to: {remote_file_path}")
+    logger.debug("Trying to backup file to: %s", remote_file_path)
     if remote_file_path is not None:
         mkdirp(os.path.dirname(remote_file_path))
         if keep_original:
@@ -227,10 +227,10 @@ def url_exists(url):
 def _debug_print_delete_results(result):
     if "Deleted" in result:
         for d in result["Deleted"]:
-            logger.debug(f'Deleted {d["Key"]}')
+            logger.debug("Deleted %s", d["Key"])
     if "Errors" in result:
         for e in result["Errors"]:
-            logger.debug(f'Failed to delete {e["Key"]} ({e["Message"]})')
+            logger.debug("Failed to delete %s (%s)", e["Key"], e["Message"])
 
 
 def remove_url(url, recursive=False):
@@ -455,10 +455,10 @@ def spider(root_urls, depth=0, concurrency=32):
         except Exception as e:
             # Other types of errors are completely ignored,
             # except in debug mode
-            logger.debug(f"Error in _spider: {type(e)}:{str(e)}", traceback.format_exc())
+            logger.debug("Error in _spider: %s:%s\n%s", type(e), str(e), traceback.format_exc())
 
         finally:
-            logger.debug(f"SPIDER: [url={url}]")
+            logger.debug("SPIDER: [url=%s]", url)
 
         return pages, links, subcalls
 

--- a/lib/ramble/ramble/util/yaml_generation.py
+++ b/lib/ramble/ramble/util/yaml_generation.py
@@ -42,7 +42,7 @@ def read_config_file(conf_path: str):
         (dict): Dictionary representation of the data contained in conf_path
     """
     with open(conf_path) as base_conf:
-        logger.debug(f"Reading config from {conf_path}")
+        logger.debug("Reading config from %s", conf_path)
         try:
             config_dict = syaml.load(base_conf)
         except yaml.YAMLError:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -130,7 +130,7 @@ def valid_workspace_name(name):
 
 def validate_workspace_name(name):
     if not valid_workspace_name(name):
-        logger.debug(f"Validation failed for {name}")
+        logger.debug("Validation failed for %s", name)
         raise ValueError(
             (
                 "'%s': names must start with a letter, and only contain "
@@ -161,7 +161,7 @@ def activate(ws):
     # below.
     prepare_config_scope(ws)
 
-    logger.debug(f"Using workspace '{ws.root}'")
+    logger.debug("Using workspace '%s'", ws.root)
 
     # Do this last, because setting up the config must succeed first.
     _active_workspace = ws
@@ -174,7 +174,7 @@ def deactivate():
     if not _active_workspace:
         return
 
-    logger.debug(f"Deactivated workspace '{_active_workspace.root}'")
+    logger.debug("Deactivated workspace '%s'", _active_workspace.root)
 
     deactivate_config_scope(_active_workspace)
 
@@ -440,7 +440,7 @@ class Workspace:
     hash_file_name = "workspace_hash.sha256"
 
     def __init__(self, root, dry_run=False, read_default_template=True):
-        logger.debug(f"In workspace init. Root = {root}")
+        logger.debug("In workspace init. Root = %s", root)
         self.root = ramble.util.path.canonicalize_path(root)
         self.txlock = lk.Lock(self._transaction_lock_path)
         self.dry_run = dry_run
@@ -849,7 +849,7 @@ ramble:
         """
 
         ws_dict = self._get_workspace_dict()
-        logger.debug(f" With ws dict: {ws_dict}")
+        logger.debug(" With ws dict: %s", ws_dict)
 
         # Iterate over applications in ramble.yaml first
         app_dict = ramble.config.config.get_config(namespace.application)
@@ -1214,7 +1214,7 @@ ramble:
                 # If version validation fails (e.g. unknown version in strict mode),
                 # we still want to allow adding the experiment to the config.
                 # Full validation will happen during concretization/setup.
-                logger.debug(f"Version initialization failed for {application}: {e}")
+                logger.debug("Version initialization failed for %s: %s", application, e)
                 pass
         elif hasattr(app_inst, "preferred_version"):
             try:
@@ -1223,7 +1223,7 @@ ramble:
             except (ramble.error.RambleError, ramble.error.ObjectValidationError) as e:
                 # If version validation fails, we still want to allow adding the experiment.
                 # Full validation will happen during concretization/setup.
-                logger.debug(f"Version initialization failed for {application}: {e}")
+                logger.debug("Version initialization failed for %s: %s", application, e)
                 pass
 
         app_inst.variables = {}
@@ -1324,7 +1324,9 @@ ramble:
             except (ramble.expander.WorkloadNotDefinedError, ramble.error.RambleError) as e:
                 # Workload may not be defined for the active 'when' conditions.
                 # Skip MPI requirement checks for now as full validation occurs later.
-                logger.debug(f"Skipping MPI requirement check for workload {workload_name}: {e}")
+                logger.debug(
+                    "Skipping MPI requirement check for workload %s: %s", workload_name, e
+                )
                 pass
             if workload_name not in workloads_dict:
                 workloads_dict[workload_name] = syaml.syaml_dict()
@@ -1489,8 +1491,8 @@ ramble:
                         and comp in packages_dict
                         and info.conflict_dict(packages_dict[comp])
                     ):
-                        logger.debug(f"  Spec 1: {str(info)}")
-                        logger.debug(f"  Spec 2: {str(packages_dict[comp])}")
+                        logger.debug("  Spec 1: %s", str(info))
+                        logger.debug("  Spec 2: %s", str(packages_dict[comp]))
                         raise RambleConflictingDefinitionError(
                             f"Compiler {comp} would be defined " "in multiple conflicting ways"
                         )
@@ -1504,7 +1506,7 @@ ramble:
                     for conf in info.config_opts():
                         ramble.config.add(conf, scope=self.ws_file_config_scope_name())
 
-            logger.debug(f"Trying to define packages for {env_name}")
+            logger.debug("Trying to define packages for %s", env_name)
             app_packages = []
             if env_name in environments_dict:
                 if namespace.packages in environments_dict[env_name]:
@@ -1515,14 +1517,14 @@ ramble:
             )
             for spec_name, definitions in software_packages.items():
                 for info in definitions:
-                    logger.debug(f"    Found spec: {spec_name}")
+                    logger.debug("    Found spec: %s", spec_name)
                     if (
                         not quiet
                         and spec_name in packages_dict
                         and info.conflict_dict(packages_dict[spec_name])
                     ):
-                        logger.debug(f"  Spec 1: {str(info)}")
-                        logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
+                        logger.debug("  Spec 1: %s", str(info))
+                        logger.debug("  Spec 2: %s", str(packages_dict[spec_name]))
                         raise RambleConflictingDefinitionError(
                             f"Package {spec_name} would be defined in multiple " "conflicting ways"
                         )
@@ -2441,7 +2443,7 @@ ramble:
         ]
 
         if len(mod_names) < 1:
-            logger.error(f"No modifiers found matching name pattern of {name_pattern}")
+            logger.error("No modifiers found matching name pattern of %s", name_pattern)
 
         added = 0
         for mod_name in mod_names:
@@ -2657,7 +2659,7 @@ ramble:
     def get_applications(self):
         """Get the dictionary of applications"""
         logger.debug("Getting app dict.")
-        logger.debug(f" {self._get_workspace_dict()}")
+        logger.debug(" %s", self._get_workspace_dict())
         workspace_dict = self._get_workspace_dict()
         if namespace.application not in workspace_dict[namespace.ramble]:
             workspace_dict[namespace.ramble][namespace.application] = syaml.syaml_dict()

--- a/var/ramble/repos/builtin.mock/applications/file-open/application.py
+++ b/var/ramble/repos/builtin.mock/applications/file-open/application.py
@@ -30,4 +30,4 @@ class FileOpen(ExecutableApplication):
         )
         with open(config_path) as conf:
             yaml.safe_load(conf)
-            logger.info(f"Config loaded from {config_path}")
+            logger.info("Config loaded from %s", config_path)

--- a/var/ramble/repos/builtin/applications/maxtext/application.py
+++ b/var/ramble/repos/builtin/applications/maxtext/application.py
@@ -269,7 +269,7 @@ class Maxtext(ExecutableApplication):
 
             model_config = app_inst.expander.expand_var("{model_config}")
             if not os.path.exists(model_config):
-                logger.debug(f"Model config file not found: {model_config}")
+                logger.debug("Model config file not found: %s", model_config)
 
     register_phase(
         "create_config", pipeline="setup", run_after=["make_experiments"]
@@ -300,7 +300,7 @@ class Maxtext(ExecutableApplication):
         with open(base_config) as conf:
             try:
                 config_data = yaml.safe_load(conf)
-                logger.debug(f"Loaded config as dict: \n{config_data}")
+                logger.debug("Loaded config as dict: \n%s", config_data)
             except yaml.YAMLError:
                 logger.die(
                     "YAML Error: Failed to load config file: {base_config}"
@@ -399,10 +399,10 @@ class Maxtext(ExecutableApplication):
                 with open(file) as f:
                     imported_metrics_data.append(f.read().strip())
             except FileNotFoundError:
-                logger.debug(f"File not found: {file}")
+                logger.debug("File not found: %s", file)
             except Exception as e:
-                logger.debug(f"An error occurred when reading file: {file}\n")
-                logger.debug(f"Error: {e}")
+                logger.debug("An error occurred when reading file: %s\n", file)
+                logger.debug("Error: %s", e)
         imported_metrics_data = "\n".join(imported_metrics_data)
 
         aggregated_metrics = {}

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -227,7 +227,7 @@ class SpackStack(ExecutableApplication):
         with open(spack_file) as f:
             spack_data = syaml.load_config(f)
 
-        logger.debug(f"Spack data: {spack_data}")
+        logger.debug("Spack data: %s", spack_data)
 
         for spec in spack_data["spack"]["specs"]:
             spec_list.append(spec)

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -933,10 +933,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
     def run_phase(self, pipeline, phase, workspace):
         """Run a phase, by getting its function pointer"""
         if self.is_template:
-            logger.debug(f"{self.name} is a template. Skipping phases")
+            logger.debug("%s is a template. Skipping phases", self.name)
             return
         if self.repeats.is_repeat_base:
-            logger.debug(f"{self.name} is a repeat base. Skipping phases")
+            logger.debug("%s is a repeat base. Skipping phases", self.name)
             return
 
         phase_node = self._pipeline_graphs[pipeline].get_node(phase)
@@ -2617,7 +2617,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
                 # Start with no active contexts in a file.
                 active_contexts = {}
-                logger.debug(f"Reading log file: {file}")
+                logger.debug("Reading log file: %s", file)
 
                 if not os.path.exists(file):
                     logger.debug(
@@ -2661,7 +2661,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                         context_match,
                                         context_conf["format"],
                                     )
-                                    logger.debug(f"Line was: {line}")
+                                    logger.debug("Line was: %s", line)
                                     logger.debug(
                                         f" Context match {context} -- {context_name}"
                                     )
@@ -3332,8 +3332,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                 files[log_path]["contexts"][context] = []
                             files[log_path]["contexts"][context].append(fom)
 
-                            logger.debug(f"Log = {log_path}")
-                            logger.debug(f"Conf = {fom_def}")
+                            logger.debug("Log = %s", log_path)
+                            logger.debug("Conf = %s", fom_def)
 
         return files, file_fom_defs, inmem_fom_defs
 
@@ -3841,7 +3841,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             self.define_variable(self.keywords.n_threads, 1)
 
         for _, obj in self._objects():
-            logger.debug(f"Setting required variables for {obj.name}")
+            logger.debug("Setting required variables for %s", obj.name)
             self.keywords.update_keys(obj.required_variables)
 
     def _format_docs_details(self, out):

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -204,10 +204,10 @@ class GcpMetadata(BasicModifier):
         with open(log_path) as f:
             for raw_host in f.readlines():
                 physical_host = raw_host[1:].strip()
-                logger.debug(f"  Host line: {physical_host}")
+                logger.debug("  Host line: %s", physical_host)
                 all_hosts.add(physical_host)
                 levels = physical_host.split("/")
-                logger.debug(f"   Levels: {levels}")
+                logger.debug("   Levels: %s", levels)
                 if len(levels) == 3:
                     level0_groups.add(levels[0])
                     level1_groups.add(levels[1])

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -144,7 +144,7 @@ class Pip(PackageManagerBase):
             workspace.add_to_cache(cache_tupl)
 
         env_context = app_inst.expander.expand_var_name(self.keywords.env_name)
-        logger.debug(f" Required environment: {self.environment_required}")
+        logger.debug(" Required environment: %s", self.environment_required)
         try:
             self.runner.set_dry_run(workspace.dry_run)
             self.runner.configure_env(env_path)

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -84,7 +84,7 @@ class SpackLightweight(PackageManagerBase):
 
         cache_tupl = ("spack-compilers", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug(f"{cache_tupl} already in cache.")
+            logger.debug("%s already in cache.", cache_tupl)
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -147,7 +147,7 @@ class SpackLightweight(PackageManagerBase):
 
         cache_tupl = ("spack-env", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug(f"{cache_tupl} already in cache.")
+            logger.debug("%s already in cache.", cache_tupl)
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -272,7 +272,7 @@ class SpackLightweight(PackageManagerBase):
 
         cache_tupl = ("concretize-env", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug(f"{cache_tupl} already in cache.")
+            logger.debug("%s already in cache.", cache_tupl)
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -328,7 +328,7 @@ class SpackLightweight(PackageManagerBase):
 
         cache_tupl = ("spack-mirror", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug(f"{cache_tupl} already in cache.")
+            logger.debug("%s already in cache.", cache_tupl)
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -389,7 +389,7 @@ class SpackLightweight(PackageManagerBase):
         env_path = app_inst.expander.env_path
         cache_tupl = ("push-to-cache", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug(f"{cache_tupl} already pushed, skipping")
+            logger.debug("%s already pushed, skipping", cache_tupl)
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -1380,7 +1380,7 @@ class SpackRunner(CommandRunner):
         base_args = ["buildcache", "push"]
         user_flags = ramble.config.get(f"{self.buildcache_config_name}:flags")
 
-        logger.debug(f"Running with user flags: {user_flags}")
+        logger.debug("Running with user flags: %s", user_flags)
 
         if user_flags is not None:
             base_args.extend(shlex.split(user_flags))

--- a/var/ramble/repos/builtin/package_managers/spack/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack/package_manager.py
@@ -38,7 +38,7 @@ class Spack(SpackLightweight):
 
         cache_tupl = ("spack-install", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug(f"{cache_tupl} already in cache.")
+            logger.debug("%s already in cache.", cache_tupl)
             return
         else:
             workspace.add_to_cache(cache_tupl)


### PR DESCRIPTION
Replace f-strings in all logger calls to defer evaluation if the logger is not enabled. This should improve performance.