### PR TITLE
Add intel-hpcg and update intel-hpl to use shared mkl base application

### DIFF
--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -512,7 +512,8 @@ def stage_files(
     files that are not managed by the `input_file` directive.
 
     The staging method is controlled by the `stage_method` configuration
-    option, which can be set to 'cp', 'rsync', 'symbolic_link', or 'hard_link'.
+    option, which can be set to 'cp', 'rsync', 'symbolic_link', 'hard_link',
+    or 'install' (for files only).
 
     Args:
         src (str | None): The source path of the file or directory.
@@ -522,17 +523,19 @@ def stage_files(
                                                of src, dest locations to stage.
         name (str | None): The name of the executable. Defaults to 'stage-files'.
         method (str): The method to use for this stage. Can be one of:
-                      "user-defined", "cp", "rsync", "symbolic_link", "hard_link"
+                      "user-defined", "cp", "rsync", "symbolic_link",
+                      "hard_link", "install"
         when (list | None): List of when conditions to apply to this directive.
     """
 
-    valid_methods = ["user-defined", "cp", "rsync", "symbolic_link", "hard_link"]
+    valid_methods = ["user-defined", "cp", "rsync", "symbolic_link", "hard_link", "install"]
 
     method_map = {
         "cp": "cp -Lr",
         "rsync": "rsync -Lr",
         "symbolic_link": "ln -sf",
         "hard_link": "ln -f",
+        "install": "install -m 755",
     }
 
     def _execute_stage_files(app):

--- a/var/ramble/repos/builtin/applications/intel-hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpcg/application.py
@@ -1,0 +1,88 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+from ramble.appkit import *
+from ramble.base_app.builtin.hpcg import Hpcg as HpcgBase
+from ramble.base_app.builtin.intel_mkl_benchmarks import (
+    IntelMklBenchmarks as IntelMklBenchmarksBase,
+)
+
+
+class IntelHpcg(HpcgBase, IntelMklBenchmarksBase):
+    """Define HPCG application using Intel MKL optimized binary from intel-oneapi-mkl package"""
+
+    name = "intel-hpcg"
+
+    maintainers("dapomeroy")
+
+    tags("intel-optimized")
+
+    with when("package_manager_family=spack"):
+        define_compiler("gcc14", pkg_spec="gcc@14.2.0")
+        software_spec(
+            "imkl_{application::intel-hpcg::version}",
+            pkg_spec="intel-oneapi-mkl@{application::intel-hpcg::version} threads=openmp",
+            compiler="gcc14",
+        )
+        software_spec(
+            "impi2021p17",
+            pkg_spec="intel-oneapi-mpi@2021.17.2",
+        )
+
+        required_package("intel-oneapi-mkl")
+
+    executable(
+        "set_vars", "source {intel-oneapi-mkl_path}/setvars.sh", use_mpi=False
+    )  # required to link libiomp5.so
+    executable("execute", "{hpcg_exec_path}", use_mpi=True)
+    executable(
+        "move-log", "mv n[0-9]*-[0-9]*p-[0-9]*t*.txt {out_file}", use_mpi=False
+    )
+    executable(
+        "reformat-output",  # Removes spaces to match OSS HPCG formatting
+        template=[
+            "sed -i 's/ Final Summary ::/Final Summary::/g' {out_file}",
+            "sed -i 's/    HPCG 2.4 Rating/HPCG 2.4 Rating/g' {out_file}",
+        ],
+        use_mpi=False,
+    )
+
+    workload(
+        "standard",
+        executables=["set_vars", "execute", "move-log", "reformat-output"],
+    )
+
+    workload_group("all_workloads", workloads=["standard"], mode="append")
+
+    workload_variable(
+        "exec_name",
+        default="xhpcg_avx512",
+        values=[
+            "xhpcg_avx2",
+            "xhpcg_avx2_int64",
+            "xhpcg_avx512",
+            "xhpcg_avx512_int64",
+            "xhpcg_skx",
+            "xhpcg_skx_int64",
+            "xhpcg_sse42",
+            "xhpcg_sse42_int64",
+        ],
+        description="Name of executable to use for Intel HPCG",
+        workload_group="all_workloads",
+    )
+
+    workload_variable(
+        "hpcg_exec_path",
+        default=os.path.join(
+            "{mkl_benchmark_path}", "hpcg", "hpcg_cpu", "bin", "{exec_name}"
+        ),
+        description="Path to HPCG executable",
+        workload_group="all_workloads",
+    )

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -6,12 +6,17 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import os
+
 from ramble.appkit import *
 from ramble.base_app.builtin.hpl import Hpl as HplBase
+from ramble.base_app.builtin.intel_mkl_benchmarks import (
+    IntelMklBenchmarks as IntelMklBenchmarksBase,
+)
 
 
-class IntelHpl(HplBase):
-    """Define HPL application using Intel MKL optimized binary from intel-oneapi-mpi package"""
+class IntelHpl(HplBase, IntelMklBenchmarksBase):
+    """Define HPL application using Intel MKL optimized binary from intel-oneapi-mkl package"""
 
     name = "intel-hpl"
 
@@ -19,65 +24,83 @@ class IntelHpl(HplBase):
 
     tags("intel-optimized")
 
-    version(
-        "2024.2.0",
-        "Version 2024.2.0 of intel-oneapi-mkl with HPL",
-        preferred=True,
-    )
-
     with when("package_manager_family=spack"):
-        define_compiler("gcc13p2", pkg_spec="gcc@13.2.0")
+        define_compiler("gcc14", pkg_spec="gcc@14.2.0")
+
         software_spec(
             "imkl_{application::intel-hpl::version}",
             pkg_spec="intel-oneapi-mkl@{application::intel-hpl::version} threads=openmp",
-            compiler="gcc13p2",
+            compiler="gcc14",
         )
         software_spec(
-            "impi2021p13",
-            pkg_spec="intel-oneapi-mpi@2021.13.1",
+            "impi2021p17",
+            pkg_spec="intel-oneapi-mpi@2021.17.2",
         )
 
         required_package("intel-oneapi-mkl")
 
-    # This step does a few things:
-    # - Prepare calling for the script runme_intel64_prv
-    #   (We call this runner script instead of the underlying xhpl_intel64_dynamic
-    #    since it sets up derived env var HPL_HOST_NODE for numa placement control.)
-    # - Copy in the xhpl_intel64_dynamic binary to the running dir
-    #   (This is needed due to runme_intel64_prv invoking it using "./")
-    # - Account for newer directory layout from mkl 2024
+    #  We call the runme_intel64_prv script instead of the underlying xhpl_intel64_dynamic
+    #  since it sets up derived env var HPL_HOST_NODE for numa placement control.
+    #  We copy in the xhpl_intel64_dynamic binary to the running dir
+    #  because runme_intel64_prv invokes it using "./"
     stage_files(
         name="stage-binary",
-        src="${hpl_bench_dir}/xhpl_intel64_dynamic",
-        dst="{experiment_run_dir}/.",
+        src=os.path.join("{hpl_bench_dir}", "xhpl_intel64_dynamic"),
+        dst=os.path.join("{experiment_run_dir}", "."),
+        method="cp",
     )
-    executable(
-        "prepare",
-        template=[
-            r"""
-hpl_bench_dir="{intel-oneapi-mkl_path}/mkl/latest/benchmarks/mp_linpack"
-if [ ! -d ${hpl_bench_dir} ]; then
-    hpl_bench_dir="{intel-oneapi-mkl_path}/mkl/latest/share/mkl/benchmarks/mp_linpack"
-fi
-hpl_run="${hpl_bench_dir}/runme_intel64_prv"
-    """.strip()
-        ],
-        mpi=False,
-        redirect="",
-        output_capture="",
+
+    stage_files(
+        name="stage-runme",
+        src=os.path.join("{hpl_bench_dir}", "runme_intel64_prv.txt"),
+        dst=os.path.join("{experiment_run_dir}", "runme_intel64_prv"),
+        method="install",
     )
 
     executable(
         "execute",
-        "${hpl_run}",
+        "{hpl_run_script}",
         use_mpi=True,
     )
 
-    workload("standard", executables=["prepare", "stage-binary", "execute"])
-    workload("calculator", executables=["prepare", "stage-binary", "execute"])
+    # At 2025.0.1, the runme_intel64_prv script was changed to .txt format
+    # (runme_intel64_dynamic was changed to .txt at 2025.1.0)
+    with when("application_version@:2025.0.0"):
+        workload("standard", executables=["stage-binary", "execute"])
+        workload("calculator", executables=["stage-binary", "execute"])
+
+        workload_variable(
+            "hpl_run_script",
+            default=os.path.join("{hpl_bench_dir}", "runme_intel64_prv"),
+            description="Path to the HPL run script.",
+            workloads=["*"],
+        )
+
+    with when("application_version@2025.0.1:"):
+        workload(
+            "standard", executables=["stage-binary", "stage-runme", "execute"]
+        )
+        workload(
+            "calculator",
+            executables=["stage-binary", "stage-runme", "execute"],
+        )
+
+        workload_variable(
+            "hpl_run_script",
+            default=os.path.join("{experiment_run_dir}", "runme_intel64_prv"),
+            description="Path to the HPL run script.",
+            workloads=["*"],
+        )
 
     workload_group("standard", workloads=["standard"], mode="append")
     workload_group("calculator", workloads=["calculator"], mode="append")
+
+    workload_variable(
+        "hpl_bench_dir",
+        default=os.path.join("{mkl_benchmark_path}", "mp_linpack"),
+        description="Path to Intel HPL benchmarks directory",
+        workloads=["*"],
+    )
 
     environment_variable(
         "MPI_PROC_NUM",

--- a/var/ramble/repos/builtin/base_applications/intel-mkl-benchmarks/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/intel-mkl-benchmarks/base_application.py
@@ -1,0 +1,98 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+from ramble.appkit import *
+
+
+class IntelMklBenchmarks(ExecutableApplication):
+    """The Intel MKL Benchmarks collection provides two benchmarks (HPL and
+    HPCG), widely used in the HPC community optimized for performance on Intel
+    hardware.
+    """
+
+    name = "intel-mkl-benchmarks"
+
+    maintainers("dapomeroy")
+
+    tags("cpu-benchmark", "gpu-benchmark", "intel-optimized")
+
+    version(
+        "2026.0.0",
+        "Version 2026.0.0 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2025.3.1",
+        "Version 2025.3.1 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2025.3.0",
+        "Version 2025.3.0 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2025.2.0",
+        "Version 2025.2.0 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2025.1.1",
+        "Version 2025.1.1 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2025.0.0",
+        "Version 2025.0.0 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2024.2.2",
+        "Version 2024.2.2 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2024.2.1",
+        "Version 2024.2.1 of intel-oneapi-mkl",
+        preferred=False,
+    )
+    version(
+        "2024.2.0",
+        "Version 2024.2.0 of intel-oneapi-mkl",
+        preferred=True,
+    )
+    version(
+        "2023.2.0",
+        "Version 2023.2.0 of intel-oneapi-mkl",
+        preferred=False,
+    )
+
+    variable(
+        "mkl_benchmark_path",
+        default=os.path.join(
+            "{intel-oneapi-mkl_path}",
+            "mkl",
+            "latest",
+            "share",
+            "mkl",
+            "benchmarks",
+        ),
+        description="Path to MKL benchmarks",
+        when="application_version@2024:",
+    )
+
+    variable(
+        "mkl_benchmark_path",
+        default=os.path.join(
+            "{intel-oneapi-mkl_path}", "mkl", "latest", "benchmarks"
+        ),
+        description="Path to MKL benchmarks (version < 2024)",
+        when="application_version@:2023",
+    )


### PR DESCRIPTION
Updates Intel-optimized benchmarks
* Adds `intel-hpcg` application definition
* Adds `intel-mkl-benchmarks` base application definition
* Updates `intel-hpl` to use mkl base app and app versions
* Adds `install` method in `stage_files()` directive 