### PR TITLE
Support `@<version_spec>` syntax in `when`

### DIFF
--- a/lib/ramble/docs/dev_guides/application_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/application_dev_guide.rst
@@ -340,6 +340,10 @@ and ``when`` conditions can be described using the following syntax:
 * ``application_version@<start_number>:<end_number>`` Apply to a range of
   versions, inclusive of specified versions.
 
+Ramble also allows the shorthand ``@<version_spec>`` syntax, where Ramble will
+automatically prefix it with the origin type of the object containing the
+directive (e.g., ``application_version`` or ``modifier_version``).
+
 Ramble relies on `Python packaging.version`_ to calculate whether a version
 satisfies ``when`` criteria. In some cases, it may be necessary to adjust the
 format of version numbers to conform with `PEP 440 version specifiers`_. For

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -307,6 +307,13 @@ def build_when_list(
                     "string or list."
                 )
         when_list.extend(when_arg)
+
+        # Enable '@{version}' syntax in `when` clauses
+        if hasattr(obj, "origin_type") and obj.origin_type:
+            for i, w in enumerate(when_list):
+                if w.startswith("@"):
+                    when_list[i] = f"{obj.origin_type}_version{w}"
+
     return when_list
 
 

--- a/lib/ramble/ramble/test/impossible_when.py
+++ b/lib/ramble/ramble/test/impossible_when.py
@@ -44,11 +44,11 @@ def test_info_version_impossible(mock_applications):
     wl1_part = parts[1]
     wl2_part = parts[2]
 
-    assert "When: @1.0" in wl1_part
+    assert "When: application_version@1.0" in wl1_part
     assert "var1" in wl1_part
     assert "var2" not in wl1_part
 
-    assert "When: @2.0" in wl2_part
+    assert "When: application_version@2.0" in wl2_part
     assert "var2" in wl2_part
     assert "var1" not in wl2_part
 

--- a/var/ramble/repos/builtin.mock/applications/version-impossible/application.py
+++ b/var/ramble/repos/builtin.mock/applications/version-impossible/application.py
@@ -14,6 +14,9 @@ class VersionImpossible(ExecutableApplication):
 
     executable("base_exec", "echo 'base'", use_mpi=False)
 
+    version("1.0", description="version-impossible 1.0", preferred=True)
+    version("2.0", description="version-impossible 2.0", preferred=False)
+
     workload("wl1", executable="base_exec", when="@1.0")
     workload("wl1", executable="base_exec", when="@2.0")
 

--- a/var/ramble/repos/builtin.mock/applications/versions/application.py
+++ b/var/ramble/repos/builtin.mock/applications/versions/application.py
@@ -25,6 +25,14 @@ class Versions(VersionsBase):
             description="Variable to print for testing",
         )
 
+        environment_variable(
+            "APP_ENV_VAR",
+            value="APP_ENV_VAR_SET",
+            description="Test app environment variable",
+            workload="test_wl",
+            when=["@:0.9"],
+        )
+
     version("2.0a1", description="Versions 2.0 alpha", preferred=False)
     version("1.0", description="Versions 1.0", preferred=True)
     version("0.9", description="Versions 0.9", preferred=False)
@@ -41,7 +49,7 @@ class Versions(VersionsBase):
         with when("application_version@0.9:1.0"):
             software_spec("zlib-range", pkg_spec="zlib@1.2.12")
 
-        with when("application_version@:0.9"):
+        with when("@:0.9"):
             software_spec("zlib-less", pkg_spec="zlib@1.2.11")
 
         required_package("zlib")

--- a/var/ramble/repos/builtin.mock/modifiers/versions-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/versions-mod/modifier.py
@@ -19,14 +19,14 @@ class VersionsMod(BasicModifier):
     version("2.0", "versionsmod 2.0", preferred=True)
     version("1.0", "versionsmod 1.0", preferred=False)
 
-    with when("modifier_version=1.0"):
+    with when("modifier_version@1.0"):
         environment_variable(
             "MOD_ENV_VAR",
             value="MOD_ENV_VAR_SET_1.0",
             description="Test environment variable",
         )
 
-    with when("modifier_version=2.0"):
+    with when("@2.0"):
         environment_variable(
             "MOD_ENV_VAR",
             value="MOD_ENV_VAR_SET_2.0",


### PR DESCRIPTION
Adds support for a simplified version syntax in `when` clauses. Instead of using `with when("application_version@1.0"):` in an object definition, a shorter `with when("@1.0"):` can be used and the object origin type will be added by Ramble.