### PR TITLE
Implement Filter Groups [AI]

### DIFF
--- a/etc/ramble/defaults/filter_groups.yaml
+++ b/etc/ramble/defaults/filter_groups.yaml
@@ -10,18 +10,15 @@ filter_groups:
   success:
     where:
     - '"{experiment_status}" == "SUCCESS"'
-  notsuccess:
-    where:
-    - '"{experiment_status}" != "SUCCESS"'
   failed:
     where:
     - '"{experiment_status}" == "FAILED"'
-  notfailed:
-    where:
-    - '"{experiment_status}" != "FAILED"'
   repeat_base:
     where:
-    - "{repeat_index} == 0"
+    - "{is_repeat_parent} == True"
   repeats_only:
     where:
-    - "{repeat_index} != 0"
+    - "{is_repeat_child} == True"
+  first_repeat:
+    where:
+    - "{repeat_index} == 1"

--- a/etc/ramble/defaults/filter_groups.yaml
+++ b/etc/ramble/defaults/filter_groups.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+filter_groups:
+  success:
+    where:
+    - '"{experiment_status}" == "SUCCESS"'
+  notsuccess:
+    where:
+    - '"{experiment_status}" != "SUCCESS"'
+  failed:
+    where:
+    - '"{experiment_status}" == "FAILED"'
+  notfailed:
+    where:
+    - '"{experiment_status}" != "FAILED"'
+  repeat_base:
+    where:
+    - "{repeat_index} == 0"
+  repeats_only:
+    where:
+    - "{repeat_index} != 0"

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -352,6 +352,57 @@ actions is available. These actions are:
   definition. Only supports paths, delimiter is ``:``
 * ``unset`` - Remove a variable definition, if it is set.
 
+.. _filter-groups-config:
+
+----------------------
+Filter Groups Section:
+----------------------
+
+The filter groups config section is named ``filter_groups`` and allows users to
+define persistent, named groups of filters. These groups can be referenced in
+commands to easily select subsets of experiments (e.g., specific workloads,
+scaling studies) without typing complex logical expressions on the CLI.
+
+Filter groups can be defined globally in ``~/.ramble/filter_groups.yaml`` (user scope)
+or per-workspace in ``$workspace/configs/ramble.yaml`` (workspace scope).
+
+The format of this config section is as follows:
+
+.. code-block:: yaml
+
+    filter_groups:
+      small-scale:
+        where:
+        - "{n_nodes} < 4"
+        exclude_where:
+        - "'{mpi_provider}' == 'tcp'"
+      large-scale:
+        where:
+        - "{n_nodes} >= 8"
+
+Each filter group maps to an object containing lists of filter expressions:
+
+* ``where``: A list of inclusive filter expressions. All expressions must evaluate to ``True`` for an experiment to be included.
+* ``exclude_where``: A list of exclusive filter expressions. If any expression evaluates to ``True``, the experiment is excluded.
+
+These groups can then be used on the CLI using the ``-fg`` / ``--filter-group`` (inclusive) and ``-efg`` / ``--exclude-filter-group`` (exclusive) flags on commands like ``ramble on`` or ``ramble workspace setup``. Multiple filter groups can be combined in a single flag using logical expressions (supporting ``and``, ``or``, ``not``, and parentheses):
+
+.. code-block:: console
+
+    $ ramble on -fg "small-scale and not single-node"
+
+Global filter groups can be managed using the top-level ``ramble filter-groups`` command:
+
+.. code-block:: console
+
+    $ ramble filter-groups add -n global-small -w "{n_nodes} < 2"
+    $ ramble filter-groups remove -n global-small
+    $ ramble filter-groups list
+    $ ramble filter-groups blame
+
+By default, these commands edit the global ``user`` scope. You can target a different scope (such as ``workspace``) using the ``--scope`` option.
+
+
 .. _formatted-execs-config:
 
 ------------------------------

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -395,12 +395,14 @@ Global filter groups can be managed using the top-level ``ramble filter-groups``
 
 .. code-block:: console
 
-    $ ramble filter-groups add -n global-small -w "{n_nodes} < 2"
+    $ ramble filter-groups add -n global-small --where "{n_nodes} < 2"
     $ ramble filter-groups remove -n global-small
     $ ramble filter-groups list
     $ ramble filter-groups blame
 
 By default, these commands edit the global ``user`` scope. You can target a different scope (such as ``workspace``) using the ``--scope`` option.
+
+Alternatively, workspace-scoped filter groups can also be managed using the :ref:`workspace-manage` command.
 
 
 .. _formatted-execs-config:

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -366,6 +366,8 @@ scaling studies) without typing complex logical expressions on the CLI.
 Filter groups can be defined globally in ``~/.ramble/filter_groups.yaml`` (user scope)
 or per-workspace in ``$workspace/configs/ramble.yaml`` (workspace scope).
 
+If a filter group with the same name is defined in multiple configuration scopes (e.g., in both the user scope and a workspace scope), the definition in the higher-precedence scope completely overrides any definitions from lower-precedence scopes. The definitions (including the ``where`` and ``exclude_where`` lists) are not merged.
+
 The format of this config section is as follows:
 
 .. code-block:: yaml

--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -196,6 +196,15 @@ at the desired configuration granularity.
     $ ramble config add 'config:enable_workspace_prompt:true'
 
 
+A filter group can also be persistently activated for a workspace session by passing the ``-fg`` / ``--filter-group`` flag to the ``activate`` command:
+
+.. code-block:: console
+
+    $ ramble workspace activate <workspace_name> -fg small-scale
+
+This will export the ``RAMBLE_ACTIVE_FILTER_GROUP`` environment variable to the shell, which will be used by subsequent workspace commands as the default filter group. Deactivating the workspace will unset this variable.
+
+
 ------------------------------
 Printing Workspace Information
 ------------------------------
@@ -302,6 +311,18 @@ a workspace (``workspace``, ``application``, ``application:workload``, or
 
 Finally, ``ramble workspace manage includes`` can be used to quickly and easy
 add includes when using a hierarchical workspace.
+
+Filter groups can also be managed via the CLI using the ``ramble workspace manage filter-groups`` subcommand:
+
+.. code-block:: console
+
+  $ ramble workspace manage filter-groups add -n small-scale -w "{n_nodes} < 4"
+  $ ramble workspace manage filter-groups remove -n small-scale
+  $ ramble workspace manage filter-groups list
+  $ ramble workspace manage filter-groups blame
+
+These commands allow adding, removing, listing, and viewing the sources (blame) of filter groups within the active workspace.
+
 
 ---------------------
 Workspace Deployments

--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -476,10 +476,12 @@ Filtering Experiments
 Several of the workspace commands support filtering the experiments they should
 act on. This can be performed using the ``--where`` argument for inclusive
 filtering, the ``--exclude-where`` argument for exclusive filtering, or the
-``--filter-tags`` argument to filter based on experiment tags.. These arguments
+``--filter-tags`` argument to filter based on experiment tags. These arguments
 take a string representing a logical expression, which can use variables the
-experiment would define. If the logical expression evaluates to true, the
-experiment will be included or excluded for action (respectively).
+experiment would define. The expression can use any of the logical and mathematical
+operators supported by Ramble variables (see :ref:`ramble-supported-functions`).
+If the logical expression evaluates to true, the experiment will be included or
+excluded for action (respectively).
 
 As an example:
 

--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -316,7 +316,7 @@ Filter groups can also be managed via the CLI using the ``ramble workspace manag
 
 .. code-block:: console
 
-  $ ramble workspace manage filter-groups add -n small-scale -w "{n_nodes} < 4"
+  $ ramble workspace manage filter-groups add -n small-scale --where "{n_nodes} < 4"
   $ ramble workspace manage filter-groups remove -n small-scale
   $ ramble workspace manage filter-groups list
   $ ramble workspace manage filter-groups blame

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -165,6 +165,7 @@ Supported math operators are:
 * ``<=`` (less or equal than)
 * ``and`` (logical and)
 * ``or`` (logical or)
+* ``not`` (logical not)
 * ``%`` (modulo)
 * ``&`` (bitwise and)
 * ``|`` (bitwise or)

--- a/lib/ramble/ramble/cmd/common/arguments.py
+++ b/lib/ramble/ramble/cmd/common/arguments.py
@@ -222,7 +222,7 @@ def no_checksum():
 @arg
 def filter_group():
     return Args(
-        "-fg",
+        "--fg",
         "--filter-group",
         dest="filter_group",
         help="Filter experiments using a logical expression of filter groups",
@@ -233,7 +233,7 @@ def filter_group():
 @arg
 def exclude_filter_group():
     return Args(
-        "-efg",
+        "--efg",
         "--exclude-filter-group",
         dest="exclude_filter_group",
         help="Exclude experiments matching a logical expression of filter groups",

--- a/lib/ramble/ramble/cmd/common/arguments.py
+++ b/lib/ramble/ramble/cmd/common/arguments.py
@@ -217,3 +217,25 @@ def no_checksum():
         default=False,
         help="do not use checksums to verify downloaded files (unsafe)",
     )
+
+
+@arg
+def filter_group():
+    return Args(
+        "-fg",
+        "--filter-group",
+        dest="filter_group",
+        help="Filter experiments using a logical expression of filter groups",
+        required=False,
+    )
+
+
+@arg
+def exclude_filter_group():
+    return Args(
+        "-efg",
+        "--exclude-filter-group",
+        dest="exclude_filter_group",
+        help="Exclude experiments matching a logical expression of filter groups",
+        required=False,
+    )

--- a/lib/ramble/ramble/cmd/config.py
+++ b/lib/ramble/ramble/cmd/config.py
@@ -28,15 +28,16 @@ level = "long"
 
 
 def setup_parser(subparser):
-    scopes = ramble.config.scopes()
     scopes_metavar = ramble.config.scopes_metavar
 
     # User can only choose one
     subparser.add_argument(
+        "-s",
         "--scope",
-        choices=scopes,
+        choices=ramble.config.scopes_choices(include_workspace=True),
         metavar=scopes_metavar,
-        help="configuration scope to read/modify",
+        help="configuration scope to read/modify (default: user if no workspace, "
+        "workspace if active)",
     )
 
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="config_command")
@@ -113,21 +114,21 @@ def _get_scope_and_section(args):
     section = getattr(args, "section", None)
     path = getattr(args, "path", None)
 
-    # w/no args and an active workspace, point to workspace config
-    if not scope and not section:
-        ws = ramble.workspace.active_workspace()
-        if ws:
-            scope = ws.ws_file_config_scope_name()
-
-    # set scope defaults
-    elif not scope:
-        scope = ramble.config.default_modify_scope(section)
-
     # special handling for commands that take value instead of section
     if path:
         section = path[: path.find(":")] if ":" in path else path
-        if not scope:
-            scope = ramble.config.default_modify_scope(section)
+
+    if scope:
+        try:
+            scope = ramble.config.resolve_scope(scope)
+        except ValueError as e:
+            logger.die(str(e))
+    else:
+        ws = ramble.workspace.active_workspace()
+        if ws:
+            scope = ws.ws_file_config_scope_name()
+        else:
+            scope = "user"
 
     return scope, section
 
@@ -174,7 +175,7 @@ def config_edit(args):
     else:
         # If we aren't editing a ramble.yaml file, get config path from scope.
         scope, section = _get_scope_and_section(args)
-        if not scope and not section:
+        if not section and (not scope or not scope.startswith("workspace:")):
             logger.die(
                 "`ramble config edit` requires a section argument " "or an active workspace."
             )

--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -63,13 +63,23 @@ def deployment_push_setup_parser(subparser):
 
     arguments.add_common_arguments(
         subparser,
-        ["phases", "include_phase_dependencies", "where", "exclude_where", "filter_tags"],
+        [
+            "phases",
+            "include_phase_dependencies",
+            "where",
+            "exclude_where",
+            "filter_tags",
+            "filter_group",
+            "exclude_filter_group",
+        ],
     )
 
 
 def deployment_push(args):
     current_pipeline = ramble.pipeline.pipelines.pushdeployment
     ws = ramble.cmd.require_active_workspace(cmd_name="deployment push")
+
+    args.where = ramble.filters.resolve_and_apply_filter_groups(args, args.where)
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,

--- a/lib/ramble/ramble/cmd/filter_groups.py
+++ b/lib/ramble/ramble/cmd/filter_groups.py
@@ -8,8 +8,11 @@
 
 import copy
 
+from llnl.util.tty.colify import colify
+
 import ramble.config
 import ramble.filters
+import ramble.util.colors as color
 import ramble.workspace
 from ramble.error import RambleError
 from ramble.util.logger import logger
@@ -20,15 +23,14 @@ level = "long"
 
 
 def setup_parser(subparser):
-    scopes = ramble.config.scopes()
-    # Add 'workspace' as a scope option for this command
-    scopes = list(scopes) + ["workspace"]
+    scopes_metavar = ramble.config.scopes_metavar
 
     subparser.add_argument(
         "--scope",
-        choices=scopes,
-        default="user",  # Default to global (user) scope
-        help="configuration scope to modify (default: %(default)s)",
+        choices=ramble.config.scopes_choices(include_workspace=True),
+        metavar=scopes_metavar,
+        default=None,
+        help="configuration scope to modify/list (default: user for modify, all for list)",
     )
 
     actions = subparser.add_subparsers(metavar="ACTION", dest="action")
@@ -50,17 +52,23 @@ def setup_parser(subparser):
     remove_parser = actions.add_parser("remove", aliases=["rm"], help="remove a filter group")
     remove_parser.add_argument("-n", "--name", required=True, help="name of filter group")
 
-    actions.add_parser("list", help="list defined filter groups")
+    list_parser = actions.add_parser("list", help="list defined filter groups")
+    list_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="show the filter group definition for each",
+    )
     actions.add_parser("blame", help="show defined filter groups with sources")
 
 
-def _resolve_scope(args):
-    scope = args.scope
-    if scope == "workspace":
-        ws = ramble.workspace.active_workspace()
-        if not ws:
-            logger.die("Workspace scope requires an active workspace")
-        scope = ws.ws_file_config_scope_name()
+def _resolve_scope(args, default_scope=None):
+    scope = args.scope if args.scope is not None else default_scope
+    if scope:
+        try:
+            scope = ramble.config.resolve_scope(scope)
+        except ValueError as e:
+            logger.die(str(e))
     return scope
 
 
@@ -70,16 +78,16 @@ def filter_groups(parser, args):
         parser.print_help()
         return
 
-    scope = _resolve_scope(args)
-
-    if action == "add":
-        filter_groups_add(scope, args)
-    elif action in ("remove", "rm"):
-        filter_groups_remove(scope, args)
-    elif action == "list":
-        filter_groups_list(scope, args)
+    if action == "list":
+        filter_groups_list(args)
     elif action == "blame":
         filter_groups_blame(args)
+    else:
+        scope = _resolve_scope(args, default_scope="user")
+        if action == "add":
+            filter_groups_add(scope, args)
+        elif action in ("remove", "rm"):
+            filter_groups_remove(scope, args)
 
 
 def filter_groups_add(scope, args):
@@ -100,7 +108,7 @@ def filter_groups_add(scope, args):
         group_def["exclude_where"] = args.exclude_where
 
     existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
-    if existing:
+    if existing is not None:
         logger.msg(f"Updating existing filter group '{name}' in scope '{scope}'.")
     else:
         logger.msg(f"Adding filter group '{name}' to scope '{scope}'.")
@@ -117,7 +125,7 @@ def filter_groups_remove(scope, args):
     name = args.name
 
     existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
-    if not existing:
+    if existing is None:
         logger.die(f"Filter group '{name}' not found in scope '{scope}'.")
 
     logger.msg(f"Removing filter group '{name}' from scope '{scope}'.")
@@ -135,45 +143,104 @@ def filter_groups_remove(scope, args):
             ramble.config.set("filter_groups", groups, scope=scope)
 
 
-def filter_groups_list(scope, args):
-    groups = ramble.config.get("filter_groups", scope=scope)
-    if not groups:
-        logger.msg(f"No filter groups defined in scope '{scope}'.")
+def print_filter_groups(resolved_scope_name=None, original_scope_name=None, verbose=False):
+    groups_to_print = []
+
+    if original_scope_name is not None:
+        groups = ramble.config.config.get_config("filter_groups", scope=resolved_scope_name)
+        if groups:
+            display_name = (
+                "workspace"
+                if resolved_scope_name.startswith("workspace:")
+                else resolved_scope_name
+            )
+            for name, definition in groups.items():
+                groups_to_print.append(
+                    {"scope": display_name, "name": name, "definition": definition}
+                )
+        else:
+            logger.msg(f"No filter groups defined in scope '{original_scope_name}'.")
+            return
+    else:
+        for scope in ramble.config.config:
+            try:
+                groups = ramble.config.config.get_config("filter_groups", scope=scope.name)
+                if groups:
+                    display_name = (
+                        "workspace" if scope.name.startswith("workspace:") else scope.name
+                    )
+                    for name, definition in groups.items():
+                        groups_to_print.append(
+                            {"scope": display_name, "name": name, "definition": definition}
+                        )
+            except Exception:
+                pass
+
+    if not groups_to_print:
+        logger.msg("No filter groups defined.")
         return
 
-    logger.msg(f"Filter groups defined in scope '{scope}':")
-    for name, definition in groups.items():
-        logger.msg(f"  {name}:")
-        if "where" in definition:
-            logger.msg("    where:")
-            for w in definition["where"]:
-                logger.msg(f"      - {w}")
-        if "exclude_where" in definition:
-            logger.msg("    exclude_where:")
-            for ew in definition["exclude_where"]:
-                logger.msg(f"      - {ew}")
+    if verbose:
+        current_scope = None
+        first = True
+        for item in groups_to_print:
+            scope = item["scope"]
+            name = item["name"]
+            definition = item["definition"]
+            if scope != current_scope:
+                if not first:
+                    color.cprint("")
+                first = False
+                color.cprint(f"{color.section_title('Scope:')} {scope}")
+                current_scope = scope
+
+            lines = [color.nested_1(f"    {name}:")]
+            if "where" in definition:
+                lines.append("        where:")
+                lines.extend(f"        - {w}" for w in definition["where"])
+            if "exclude_where" in definition:
+                lines.append("        exclude_where:")
+                lines.extend(f"        - {ew}" for ew in definition["exclude_where"])
+            color.cprint("\n".join(lines))
+    else:
+        scope_groups = {}
+        for item in groups_to_print:
+            scope = item["scope"]
+            name = item["name"]
+            if scope not in scope_groups:
+                scope_groups[scope] = []
+            scope_groups[scope].append(name)
+
+        out_stream = logger.active_stream()
+        colify_opts = {"indent": 4, "padding": 2}
+        if out_stream:
+            colify_opts["output"] = out_stream
+
+        first = True
+        for scope, names in scope_groups.items():
+            if not first:
+                color.cprint("", stream=out_stream)
+            first = False
+
+            color.cprint(
+                f"{color.section_title('Scope:')} {scope}",
+                stream=out_stream,
+            )
+            colify(names, **colify_opts)
+
+
+def filter_groups_list(args):
+    verbose = getattr(args, "verbose", False)
+    resolved_scope_name = None
+    if args.scope is not None:
+        resolved_scope_name = _resolve_scope(args)
+
+    print_filter_groups(
+        resolved_scope_name=resolved_scope_name,
+        original_scope_name=args.scope,
+        verbose=verbose,
+    )
 
 
 def filter_groups_blame(args):
-    logger.msg("Active filter groups (with sources):")
-    for scope in ramble.config.config:
-        try:
-            groups = ramble.config.config.get_config("filter_groups", scope=scope.name)
-            if groups:
-                try:
-                    filename = scope.get_section_filename("filter_groups")
-                except NotImplementedError:
-                    filename = "internal"
-                logger.msg(f"Scope: {scope.name} ({filename})")
-                for name, definition in groups.items():
-                    logger.msg(f"  {name}:")
-                    if "where" in definition:
-                        logger.msg("    where:")
-                        for w in definition["where"]:
-                            logger.msg(f"      - {w}")
-                    if "exclude_where" in definition:
-                        logger.msg("    exclude_where:")
-                        for ew in definition["exclude_where"]:
-                            logger.msg(f"      - {ew}")
-        except Exception:
-            pass
+    ramble.config.config.print_section("filter_groups", blame=True)

--- a/lib/ramble/ramble/cmd/filter_groups.py
+++ b/lib/ramble/ramble/cmd/filter_groups.py
@@ -9,7 +9,9 @@
 import copy
 
 import ramble.config
+import ramble.filters
 import ramble.workspace
+from ramble.error import RambleError
 from ramble.util.logger import logger
 
 description = "manage global or workspace-scoped filter groups"
@@ -82,6 +84,11 @@ def filter_groups(parser, args):
 
 def filter_groups_add(scope, args):
     name = args.name
+
+    try:
+        ramble.filters.validate_filter_group_name(name)
+    except RambleError as e:
+        logger.die(str(e))
 
     if not args.where and not args.exclude_where:
         logger.die("At least one of --where or --exclude-where must be specified.")

--- a/lib/ramble/ramble/cmd/filter_groups.py
+++ b/lib/ramble/ramble/cmd/filter_groups.py
@@ -34,13 +34,11 @@ def setup_parser(subparser):
     add_parser = actions.add_parser("add", help="add a filter group")
     add_parser.add_argument("-n", "--name", required=True, help="name of filter group")
     add_parser.add_argument(
-        "-w",
         "--where",
         action="append",
         help="inclusive filter expression. Can be specified multiple times.",
     )
     add_parser.add_argument(
-        "-ew",
         "--exclude-where",
         dest="exclude_where",
         action="append",

--- a/lib/ramble/ramble/cmd/filter_groups.py
+++ b/lib/ramble/ramble/cmd/filter_groups.py
@@ -1,0 +1,174 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import copy
+
+import ramble.config
+import ramble.workspace
+from ramble.util.logger import logger
+
+description = "manage global or workspace-scoped filter groups"
+section = "config"
+level = "long"
+
+
+def setup_parser(subparser):
+    scopes = ramble.config.scopes()
+    # Add 'workspace' as a scope option for this command
+    scopes = list(scopes) + ["workspace"]
+
+    subparser.add_argument(
+        "--scope",
+        choices=scopes,
+        default="user",  # Default to global (user) scope
+        help="configuration scope to modify (default: %(default)s)",
+    )
+
+    actions = subparser.add_subparsers(metavar="ACTION", dest="action")
+
+    add_parser = actions.add_parser("add", help="add a filter group")
+    add_parser.add_argument("-n", "--name", required=True, help="name of filter group")
+    add_parser.add_argument(
+        "-w",
+        "--where",
+        action="append",
+        help="inclusive filter expression. Can be specified multiple times.",
+    )
+    add_parser.add_argument(
+        "-ew",
+        "--exclude-where",
+        dest="exclude_where",
+        action="append",
+        help="exclusive filter expression. Can be specified multiple times.",
+    )
+
+    remove_parser = actions.add_parser("remove", aliases=["rm"], help="remove a filter group")
+    remove_parser.add_argument("-n", "--name", required=True, help="name of filter group")
+
+    actions.add_parser("list", help="list defined filter groups")
+    actions.add_parser("blame", help="show defined filter groups with sources")
+
+
+def _resolve_scope(args):
+    scope = args.scope
+    if scope == "workspace":
+        ws = ramble.workspace.active_workspace()
+        if not ws:
+            logger.die("Workspace scope requires an active workspace")
+        scope = ws.ws_file_config_scope_name()
+    return scope
+
+
+def filter_groups(parser, args):
+    action = args.action
+    if not action:
+        parser.print_help()
+        return
+
+    scope = _resolve_scope(args)
+
+    if action == "add":
+        filter_groups_add(scope, args)
+    elif action in ("remove", "rm"):
+        filter_groups_remove(scope, args)
+    elif action == "list":
+        filter_groups_list(scope, args)
+    elif action == "blame":
+        filter_groups_blame(args)
+
+
+def filter_groups_add(scope, args):
+    name = args.name
+
+    if not args.where and not args.exclude_where:
+        logger.die("At least one of --where or --exclude-where must be specified.")
+
+    group_def = {}
+    if args.where:
+        group_def["where"] = args.where
+    if args.exclude_where:
+        group_def["exclude_where"] = args.exclude_where
+
+    existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
+    if existing:
+        logger.msg(f"Updating existing filter group '{name}' in scope '{scope}'.")
+    else:
+        logger.msg(f"Adding filter group '{name}' to scope '{scope}'.")
+
+    ws = ramble.workspace.active_workspace()
+    if ws and scope == ws.ws_file_config_scope_name():
+        with ws.write_transaction():
+            ramble.config.set(f"filter_groups:{name}", group_def, scope=scope)
+    else:
+        ramble.config.set(f"filter_groups:{name}", group_def, scope=scope)
+
+
+def filter_groups_remove(scope, args):
+    name = args.name
+
+    existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
+    if not existing:
+        logger.die(f"Filter group '{name}' not found in scope '{scope}'.")
+
+    logger.msg(f"Removing filter group '{name}' from scope '{scope}'.")
+
+    groups = ramble.config.get("filter_groups", scope=scope)
+    if groups:
+        groups = copy.deepcopy(groups)
+        groups.pop(name, None)
+
+        ws = ramble.workspace.active_workspace()
+        if ws and scope == ws.ws_file_config_scope_name():
+            with ws.write_transaction():
+                ramble.config.set("filter_groups", groups, scope=scope)
+        else:
+            ramble.config.set("filter_groups", groups, scope=scope)
+
+
+def filter_groups_list(scope, args):
+    groups = ramble.config.get("filter_groups", scope=scope)
+    if not groups:
+        logger.msg(f"No filter groups defined in scope '{scope}'.")
+        return
+
+    logger.msg(f"Filter groups defined in scope '{scope}':")
+    for name, definition in groups.items():
+        logger.msg(f"  {name}:")
+        if "where" in definition:
+            logger.msg("    where:")
+            for w in definition["where"]:
+                logger.msg(f"      - {w}")
+        if "exclude_where" in definition:
+            logger.msg("    exclude_where:")
+            for ew in definition["exclude_where"]:
+                logger.msg(f"      - {ew}")
+
+
+def filter_groups_blame(args):
+    logger.msg("Active filter groups (with sources):")
+    for scope in ramble.config.config:
+        try:
+            groups = ramble.config.config.get_config("filter_groups", scope=scope.name)
+            if groups:
+                try:
+                    filename = scope.get_section_filename("filter_groups")
+                except NotImplementedError:
+                    filename = "internal"
+                logger.msg(f"Scope: {scope.name} ({filename})")
+                for name, definition in groups.items():
+                    logger.msg(f"  {name}:")
+                    if "where" in definition:
+                        logger.msg("    where:")
+                        for w in definition["where"]:
+                            logger.msg(f"      - {w}")
+                    if "exclude_where" in definition:
+                        logger.msg("    exclude_where:")
+                        for ew in definition["exclude_where"]:
+                            logger.msg(f"      - {ew}")
+        except Exception:
+            pass

--- a/lib/ramble/ramble/cmd/on.py
+++ b/lib/ramble/ramble/cmd/on.py
@@ -39,7 +39,16 @@ def setup_parser(subparser):
         help="Disable the logger header.",
     )
 
-    arguments.add_common_arguments(subparser, ["where", "exclude_where", "filter_tags"])
+    arguments.add_common_arguments(
+        subparser,
+        [
+            "where",
+            "exclude_where",
+            "filter_tags",
+            "filter_group",
+            "exclude_filter_group",
+        ],
+    )
 
 
 def ramble_on(args):
@@ -47,6 +56,8 @@ def ramble_on(args):
     ws = ramble.cmd.require_active_workspace(cmd_name="on")
 
     executor = args.executor if args.executor else "{batch_submit}"
+
+    args.where = ramble.filters.resolve_and_apply_filter_groups(args, args.where)
 
     filters = ramble.filters.Filters(
         phase_filters=["*"],

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1847,13 +1847,11 @@ def workspace_manage_filter_groups_setup_parser(subparser):
     add_parser = actions.add_parser("add", help="add a filter group")
     add_parser.add_argument("-n", "--name", required=True, help="name of filter group")
     add_parser.add_argument(
-        "-w",
         "--where",
         action="append",
         help="inclusive filter expression. Can be specified multiple times.",
     )
     add_parser.add_argument(
-        "-ew",
         "--exclude-where",
         dest="exclude_where",
         action="append",

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -30,6 +30,7 @@ import ramble.workspace
 import ramble.workspace.shell
 from ramble import ramble_version
 from ramble.cmd.common import arguments
+from ramble.error import RambleError
 from ramble.namespace import namespace
 from ramble.util.logger import logger
 
@@ -1882,6 +1883,11 @@ def workspace_manage_filter_groups(args):
 def workspace_manage_filter_groups_add(ws, args):
     scope = ws.ws_file_config_scope_name()
     name = args.name
+
+    try:
+        ramble.filters.validate_filter_group_name(name)
+    except RambleError as e:
+        logger.die(str(e))
 
     if not args.where and not args.exclude_where:
         logger.die("At least one of --where or --exclude-where must be specified.")

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -20,6 +20,7 @@ from llnl.util import tty
 from llnl.util.tty.colify import colified, colify
 
 import ramble.cmd
+import ramble.cmd.filter_groups
 import ramble.config
 import ramble.expander
 import ramble.filters
@@ -30,7 +31,6 @@ import ramble.workspace
 import ramble.workspace.shell
 from ramble import ramble_version
 from ramble.cmd.common import arguments
-from ramble.error import RambleError
 from ramble.namespace import namespace
 from ramble.util.logger import logger
 
@@ -139,7 +139,7 @@ def workspace_activate_setup_parser(subparser):
         help="parent directory for the named workspace to activate",
     )
     subparser.add_argument(
-        "-fg",
+        "--fg",
         "--filter-group",
         dest="filter_group",
         default=None,
@@ -796,7 +796,10 @@ def workspace_info_setup_parser(subparser):
         "--executables", action="store_true", help="If set, experiment executables will be printed"
     )
 
-    arguments.add_common_arguments(subparser, ["where", "exclude_where", "filter_tags"])
+    arguments.add_common_arguments(
+        subparser,
+        ["where", "exclude_where", "filter_tags", "filter_group", "exclude_filter_group"],
+    )
 
     subparser.add_argument(
         "-v",
@@ -812,6 +815,8 @@ def workspace_info_setup_parser(subparser):
 
 def workspace_info(args):
     ws = ramble.cmd.require_active_workspace("workspace info", args.dry_run)
+
+    args.where = ramble.filters.resolve_and_apply_filter_groups(args, args.where)
 
     # Enable verbose mode
     if args.verbose >= 1:
@@ -1843,6 +1848,16 @@ def workspace_manage_modifiers(args):
 
 def workspace_manage_filter_groups_setup_parser(subparser):
     """manage workspace filter groups"""
+    scopes_metavar = ramble.config.scopes_metavar
+
+    subparser.add_argument(
+        "--scope",
+        choices=ramble.config.scopes_choices(include_workspace=True),
+        metavar=scopes_metavar,
+        default=None,
+        help="configuration scope to modify/list",
+    )
+
     actions = subparser.add_subparsers(metavar="ACTION", dest="action")
 
     add_parser = actions.add_parser("add", help="add a filter group")
@@ -1862,7 +1877,13 @@ def workspace_manage_filter_groups_setup_parser(subparser):
     remove_parser = actions.add_parser("remove", aliases=["rm"], help="remove a filter group")
     remove_parser.add_argument("-n", "--name", required=True, help="name of filter group")
 
-    actions.add_parser("list", help="list defined filter groups")
+    list_parser = actions.add_parser("list", help="list defined filter groups")
+    list_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="show the filter group definition for each",
+    )
     actions.add_parser("blame", help="show defined filter groups with sources")
 
 
@@ -1880,97 +1901,41 @@ def workspace_manage_filter_groups(args):
         workspace_manage_filter_groups_blame(ws, args)
 
 
+def _resolve_workspace_manage_scope(ws, args, default_scope):
+    scope = args.scope if args.scope else default_scope
+    if scope:
+        try:
+            scope = ramble.config.resolve_scope(scope)
+        except ValueError as e:
+            logger.die(str(e))
+    return scope
+
+
 def workspace_manage_filter_groups_add(ws, args):
-    scope = ws.ws_file_config_scope_name()
-    name = args.name
-
-    try:
-        ramble.filters.validate_filter_group_name(name)
-    except RambleError as e:
-        logger.die(str(e))
-
-    if not args.where and not args.exclude_where:
-        logger.die("At least one of --where or --exclude-where must be specified.")
-
-    group_def = {}
-    if args.where:
-        group_def["where"] = args.where
-    if args.exclude_where:
-        group_def["exclude_where"] = args.exclude_where
-
-    existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
-    if existing:
-        logger.msg(f"Updating existing filter group '{name}' in workspace.")
-    else:
-        logger.msg(f"Adding filter group '{name}' to workspace.")
-
-    with ws.write_transaction():
-        ramble.config.set(f"filter_groups:{name}", group_def, scope=scope)
+    scope = _resolve_workspace_manage_scope(ws, args, ws.ws_file_config_scope_name())
+    ramble.cmd.filter_groups.filter_groups_add(scope, args)
 
 
 def workspace_manage_filter_groups_remove(ws, args):
-    import copy
-
-    scope = ws.ws_file_config_scope_name()
-    name = args.name
-
-    existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
-    if not existing:
-        logger.die(f"Filter group '{name}' not found in workspace scope.")
-
-    logger.msg(f"Removing filter group '{name}' from workspace.")
-
-    groups = ramble.config.get("filter_groups", scope=scope)
-    if groups:
-        groups = copy.deepcopy(groups)
-        groups.pop(name, None)
-        with ws.write_transaction():
-            ramble.config.set("filter_groups", groups, scope=scope)
+    scope = _resolve_workspace_manage_scope(ws, args, ws.ws_file_config_scope_name())
+    ramble.cmd.filter_groups.filter_groups_remove(scope, args)
 
 
 def workspace_manage_filter_groups_list(ws, args):
-    scope = ws.ws_file_config_scope_name()
-    groups = ramble.config.get("filter_groups", scope=scope)
-    if not groups:
-        logger.msg("No filter groups defined in workspace scope.")
-        return
+    verbose = getattr(args, "verbose", False)
+    resolved_scope_name = None
+    if args.scope:
+        resolved_scope_name = _resolve_workspace_manage_scope(ws, args, None)
 
-    logger.msg("Filter groups defined in workspace scope:")
-    for name, definition in groups.items():
-        logger.msg(f"  {name}:")
-        if "where" in definition:
-            logger.msg("    where:")
-            for w in definition["where"]:
-                logger.msg(f"      - {w}")
-        if "exclude_where" in definition:
-            logger.msg("    exclude_where:")
-            for ew in definition["exclude_where"]:
-                logger.msg(f"      - {ew}")
+    ramble.cmd.filter_groups.print_filter_groups(
+        resolved_scope_name=resolved_scope_name,
+        original_scope_name=args.scope,
+        verbose=verbose,
+    )
 
 
 def workspace_manage_filter_groups_blame(ws, args):
-    logger.msg("Active filter groups (with sources):")
-    for scope in ramble.config.config:
-        try:
-            groups = ramble.config.config.get_config("filter_groups", scope=scope.name)
-            if groups:
-                try:
-                    filename = scope.get_section_filename("filter_groups")
-                except NotImplementedError:
-                    filename = "internal"
-                logger.msg(f"Scope: {scope.name} ({filename})")
-                for name, definition in groups.items():
-                    logger.msg(f"  {name}:")
-                    if "where" in definition:
-                        logger.msg("    where:")
-                        for w in definition["where"]:
-                            logger.msg(f"      - {w}")
-                    if "exclude_where" in definition:
-                        logger.msg("    exclude_where:")
-                        for ew in definition["exclude_where"]:
-                            logger.msg(f"      - {ew}")
-        except Exception:
-            pass
+    ramble.config.config.print_section("filter_groups", blame=True)
 
 
 def workspace_generate_config_setup_parser(subparser):

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -72,7 +72,7 @@ subcommands = [
     "manage",
 ]
 
-manage_commands = ["experiments", "software", "includes", "modifiers"]
+manage_commands = ["experiments", "software", "includes", "modifiers", "filter-groups"]
 
 
 def workspace_activate_setup_parser(subparser):
@@ -137,6 +137,13 @@ def workspace_activate_setup_parser(subparser):
         metavar="dir",
         help="parent directory for the named workspace to activate",
     )
+    subparser.add_argument(
+        "-fg",
+        "--filter-group",
+        dest="filter_group",
+        default=None,
+        help="filter group to activate persistently",
+    )
 
 
 def create_temp_workspace_directory():
@@ -198,6 +205,7 @@ def workspace_activate(args):
         ws=active_workspace,
         shell=args.shell,
         prompt=workspace_prompt if enable_prompt else None,
+        filter_group=args.filter_group,
     )
     env_mods.extend(ramble.workspace.shell.activate(ws=active_workspace))
     cmds += env_mods.shell_modifications(args.shell)
@@ -522,6 +530,8 @@ def workspace_setup_setup_parser(subparser):
             "filter_tags",
             "profile_phases",
             "profile_phase_output",
+            "filter_group",
+            "exclude_filter_group",
         ],
     )
 
@@ -529,6 +539,8 @@ def workspace_setup_setup_parser(subparser):
 def workspace_setup(args):
     current_pipeline = ramble.pipeline.pipelines.setup
     ws = ramble.cmd.require_active_workspace("workspace setup", args.dry_run)
+
+    args.where = ramble.filters.resolve_and_apply_filter_groups(args, args.where)
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,
@@ -603,6 +615,8 @@ def workspace_analyze_setup_parser(subparser):
             "filter_tags",
             "profile_phases",
             "profile_phase_output",
+            "filter_group",
+            "exclude_filter_group",
         ],
     )
 
@@ -611,6 +625,8 @@ def workspace_analyze(args):
     current_pipeline = ramble.pipeline.pipelines.analyze
     ws = ramble.cmd.require_active_workspace("workspace analyze", args.dry_run)
     ws.repeat_success_strict = ramble.config.get("config:repeat_success_strict")
+
+    args.where = ramble.filters.resolve_and_apply_filter_groups(args, args.where)
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,
@@ -1822,6 +1838,135 @@ def workspace_manage_modifiers(args):
     elif args.list:
         with ws.read_transaction():
             ws.print_modifiers()
+
+
+def workspace_manage_filter_groups_setup_parser(subparser):
+    """manage workspace filter groups"""
+    actions = subparser.add_subparsers(metavar="ACTION", dest="action")
+
+    add_parser = actions.add_parser("add", help="add a filter group")
+    add_parser.add_argument("-n", "--name", required=True, help="name of filter group")
+    add_parser.add_argument(
+        "-w",
+        "--where",
+        action="append",
+        help="inclusive filter expression. Can be specified multiple times.",
+    )
+    add_parser.add_argument(
+        "-ew",
+        "--exclude-where",
+        dest="exclude_where",
+        action="append",
+        help="exclusive filter expression. Can be specified multiple times.",
+    )
+
+    remove_parser = actions.add_parser("remove", aliases=["rm"], help="remove a filter group")
+    remove_parser.add_argument("-n", "--name", required=True, help="name of filter group")
+
+    actions.add_parser("list", help="list defined filter groups")
+    actions.add_parser("blame", help="show defined filter groups with sources")
+
+
+def workspace_manage_filter_groups(args):
+    """Execute workspace manage filter-groups command"""
+    ws = ramble.cmd.require_active_workspace(cmd_name="workspace manage filter-groups")
+
+    if args.action == "add":
+        workspace_manage_filter_groups_add(ws, args)
+    elif args.action in ("remove", "rm"):
+        workspace_manage_filter_groups_remove(ws, args)
+    elif args.action == "list":
+        workspace_manage_filter_groups_list(ws, args)
+    elif args.action == "blame":
+        workspace_manage_filter_groups_blame(ws, args)
+
+
+def workspace_manage_filter_groups_add(ws, args):
+    scope = ws.ws_file_config_scope_name()
+    name = args.name
+
+    if not args.where and not args.exclude_where:
+        logger.die("At least one of --where or --exclude-where must be specified.")
+
+    group_def = {}
+    if args.where:
+        group_def["where"] = args.where
+    if args.exclude_where:
+        group_def["exclude_where"] = args.exclude_where
+
+    existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
+    if existing:
+        logger.msg(f"Updating existing filter group '{name}' in workspace.")
+    else:
+        logger.msg(f"Adding filter group '{name}' to workspace.")
+
+    with ws.write_transaction():
+        ramble.config.set(f"filter_groups:{name}", group_def, scope=scope)
+
+
+def workspace_manage_filter_groups_remove(ws, args):
+    import copy
+
+    scope = ws.ws_file_config_scope_name()
+    name = args.name
+
+    existing = ramble.config.get(f"filter_groups:{name}", scope=scope)
+    if not existing:
+        logger.die(f"Filter group '{name}' not found in workspace scope.")
+
+    logger.msg(f"Removing filter group '{name}' from workspace.")
+
+    groups = ramble.config.get("filter_groups", scope=scope)
+    if groups:
+        groups = copy.deepcopy(groups)
+        groups.pop(name, None)
+        with ws.write_transaction():
+            ramble.config.set("filter_groups", groups, scope=scope)
+
+
+def workspace_manage_filter_groups_list(ws, args):
+    scope = ws.ws_file_config_scope_name()
+    groups = ramble.config.get("filter_groups", scope=scope)
+    if not groups:
+        logger.msg("No filter groups defined in workspace scope.")
+        return
+
+    logger.msg("Filter groups defined in workspace scope:")
+    for name, definition in groups.items():
+        logger.msg(f"  {name}:")
+        if "where" in definition:
+            logger.msg("    where:")
+            for w in definition["where"]:
+                logger.msg(f"      - {w}")
+        if "exclude_where" in definition:
+            logger.msg("    exclude_where:")
+            for ew in definition["exclude_where"]:
+                logger.msg(f"      - {ew}")
+
+
+def workspace_manage_filter_groups_blame(ws, args):
+    logger.msg("Active filter groups (with sources):")
+    for scope in ramble.config.config:
+        try:
+            groups = ramble.config.config.get_config("filter_groups", scope=scope.name)
+            if groups:
+                try:
+                    filename = scope.get_section_filename("filter_groups")
+                except NotImplementedError:
+                    filename = "internal"
+                logger.msg(f"Scope: {scope.name} ({filename})")
+                for name, definition in groups.items():
+                    logger.msg(f"  {name}:")
+                    if "where" in definition:
+                        logger.msg("    where:")
+                        for w in definition["where"]:
+                            logger.msg(f"      - {w}")
+                    if "exclude_where" in definition:
+                        logger.msg("    exclude_where:")
+                        for ew in definition["exclude_where"]:
+                            logger.msg(f"      - {ew}")
+        except Exception:
+            pass
 
 
 def workspace_generate_config_setup_parser(subparser):

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -60,6 +60,7 @@ import ramble.schema.base_system_repos
 import ramble.schema.base_workflow_manager_repos
 import ramble.schema.config
 import ramble.schema.env_vars
+import ramble.schema.filter_groups
 import ramble.schema.formatted_executables
 import ramble.schema.internals
 import ramble.schema.licenses
@@ -94,6 +95,7 @@ section_schemas: Dict[str, Dict[str, Any]] = {
     "formatted_executables": ramble.schema.formatted_executables.schema,
     "config": ramble.schema.config.schema,
     "env_vars": ramble.schema.env_vars.schema,
+    "filter_groups": ramble.schema.filter_groups.schema,
     "internals": ramble.schema.internals.schema,
     "licenses": ramble.schema.licenses.schema,
     "mirrors": ramble.schema.mirrors.schema,

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -216,9 +216,51 @@ config_defaults = {
     }
 }
 
+
+class ScopesMetavar:
+    def __str__(self):
+        import ramble.workspace
+
+        if ramble.workspace.active_workspace():
+            return "{defaults,system,site,user,workspace}"
+        return "{defaults,system,site,user}"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class ScopesChoices:
+    def __init__(self, include_workspace=True):
+        self.include_workspace = include_workspace
+
+    def __contains__(self, item):
+        import ramble.config
+        import ramble.workspace
+
+        scopes = list(ramble.config.scopes())
+        scopes = [s for s in scopes if not s.startswith("workspace:")]
+        if self.include_workspace and ramble.workspace.active_workspace():
+            scopes.append("workspace")
+        return item in scopes
+
+    def __iter__(self):
+        import ramble.config
+        import ramble.workspace
+
+        scopes = list(ramble.config.scopes())
+        scopes = [s for s in scopes if not s.startswith("workspace:")]
+        if self.include_workspace and ramble.workspace.active_workspace():
+            scopes.append("workspace")
+        return iter(scopes)
+
+
+def scopes_choices(include_workspace=True):
+    return ScopesChoices(include_workspace)
+
+
 #: metavar to use for commands that accept scopes
 #: this is shorter and more readable than listing all choices
-scopes_metavar = "{defaults,system,site,user}"
+scopes_metavar = ScopesMetavar()
 
 #: Base name for the (internal) overrides scope.
 overrides_base_name = "overrides-"
@@ -945,7 +987,7 @@ def add_from_file(filename, scope=None):
 
             value = data[section]
             existing = get(section, scope=scope)
-            new = merge_yaml(existing, value)
+            new = merge_yaml(existing, value, path=[section])
 
             # We cannot call config.set directly (set is a type)
             config.set(section, new, scope)
@@ -995,7 +1037,7 @@ def add(fullpath, scope=None):
         value = [value]
 
     # merge value into existing
-    new = merge_yaml(existing, value)
+    new = merge_yaml(existing, value, path=process_config_path(path))
     config.set(path, new, scope)
 
 
@@ -1015,6 +1057,22 @@ def set(path, value, scope=None):
 def scopes():
     """Convenience function to get list of configuration scopes."""
     return config.scopes
+
+
+def resolve_scope(scope):
+    """Resolve a scope name to its canonical name.
+
+    If scope is 'workspace', resolve it to the active workspace's scope name.
+    """
+    if scope == "workspace":
+        import ramble.workspace
+
+        ws = ramble.workspace.active_workspace()
+        if ws:
+            return ws.ws_file_config_scope_name()
+        else:
+            raise ValueError("Workspace scope requires an active workspace")
+    return scope
 
 
 def _validate_section_name(section):
@@ -1181,7 +1239,7 @@ def get_valid_type(path):
     raise ConfigError(f"Cannot determine valid type for path '{path}'.")
 
 
-def merge_yaml(dest, source):
+def merge_yaml(dest, source, path=None):
     """Merges source into dest; entries in source take precedence over dest.
 
     This routine may modify dest and should be assigned to dest, in
@@ -1198,6 +1256,8 @@ def merge_yaml(dest, source):
     with `::` instead of `:`, and the key will override that of the
     parent instead of merging.
     """
+    if path is None:
+        path = []
 
     def they_are(t):
         return isinstance(dest, t) and isinstance(source, t)
@@ -1225,8 +1285,14 @@ def merge_yaml(dest, source):
             merge = sk in dest
             old_dest_value = dest.pop(sk, None)
 
-            if merge and not _override(sk):
-                dest[sk] = merge_yaml(old_dest_value, sv)
+            current_path = path + [sk]
+            should_override = _override(sk)
+            if not should_override:
+                if len(current_path) == 2 and current_path[0] == "filter_groups":
+                    should_override = True
+
+            if merge and not should_override:
+                dest[sk] = merge_yaml(old_dest_value, sv, current_path)
             else:
                 # if sk ended with ::, or if it's new, completely override
                 dest[sk] = copy.deepcopy(sv)

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -162,6 +162,7 @@ supported_math_operators = {
     ast.Pow: operator.pow,
     ast.BitXor: operator.xor,
     ast.USub: operator.neg,
+    ast.Not: operator.not_,
     ast.Eq: operator.eq,
     ast.NotEq: operator.ne,
     ast.Gt: operator.gt,

--- a/lib/ramble/ramble/filters.py
+++ b/lib/ramble/ramble/filters.py
@@ -76,9 +76,7 @@ def expand_filter_groups(expression: str, filter_groups_defs: Optional[dict]) ->
     # Validate expression only contains allowed characters to prevent injection or silent failures
     invalid_chars = re.sub(r"[a-zA-Z0-9_\s\(\)-]", "", expression)
     if invalid_chars:
-        from ramble.workspace import RambleWorkspaceError
-
-        raise RambleWorkspaceError(
+        raise RambleError(
             f"Invalid characters {repr(invalid_chars)} in filter group expression '{expression}'"
         )
 
@@ -95,11 +93,7 @@ def expand_filter_groups(expression: str, filter_groups_defs: Optional[dict]) ->
             group_expr = translate_group_to_predicate(group_def)
             expanded_tokens.append(f"( {group_expr} )")
         else:
-            from ramble.workspace import RambleWorkspaceError
-
-            raise RambleWorkspaceError(
-                f"Unknown filter group '{token}' in expression '{expression}'"
-            )
+            raise RambleError(f"Unknown filter group '{token}' in expression '{expression}'")
 
     return " ".join(expanded_tokens)
 
@@ -139,3 +133,15 @@ def resolve_and_apply_filter_groups(args, include_where_filters):
         logger.die(str(e))
 
     return include_where_filters
+
+
+def validate_filter_group_name(name: str):
+    """Validate filter group name to prevent reserved keywords and invalid characters."""
+    if name.lower() in ("and", "or", "not"):
+        raise RambleError(f"Filter group name '{name}' is a reserved keyword.")
+
+    if not re.match(r"^[a-zA-Z0-9_-]+$", name):
+        raise RambleError(
+            f"Filter group name '{name}' is invalid. "
+            "It can only contain alphanumeric characters, underscores, and hyphens."
+        )

--- a/lib/ramble/ramble/filters.py
+++ b/lib/ramble/ramble/filters.py
@@ -7,7 +7,12 @@
 # except according to those terms.
 
 import itertools
+import re
 from typing import List, Optional, Set
+
+import ramble.config
+from ramble.error import RambleError
+from ramble.util.logger import logger
 
 ALL_PHASES: List[str] = ["*"]
 
@@ -35,3 +40,90 @@ class Filters:
             self.exclude_where = list(itertools.chain.from_iterable(exclude_where_filters))
         if tags:
             self.tags = set(itertools.chain.from_iterable(tags))
+
+
+def translate_group_to_predicate(group_def: dict) -> str:
+    """Translate a filter group definition into a predicate string"""
+    if not group_def:
+        return "True"
+
+    where_parts = group_def.get("where", [])
+    exclude_parts = group_def.get("exclude_where", [])
+
+    if not where_parts and not exclude_parts:
+        return "True"
+
+    parts = []
+    if where_parts:
+        where_str = " and ".join(f"({w})" for w in where_parts)
+        parts.append(f"({where_str})")
+
+    if exclude_parts:
+        exclude_str = " and ".join(f"not ({e})" for e in exclude_parts)
+        parts.append(f"({exclude_str})")
+
+    return " and ".join(parts)
+
+
+def expand_filter_groups(expression: str, filter_groups_defs: dict) -> str:
+    """Expand logical expression of filter groups into a predicate string"""
+    if not expression:
+        return "True"
+
+    token_re = re.compile(r"([a-zA-Z0-9_-]+|\(|\))")
+    tokens = token_re.findall(expression)
+
+    expanded_tokens = []
+    for token in tokens:
+        low_token = token.lower()
+        if low_token in ("and", "or", "not", "(", ")"):
+            expanded_tokens.append(low_token)
+        elif token in filter_groups_defs:
+            group_def = filter_groups_defs[token]
+            group_expr = translate_group_to_predicate(group_def)
+            expanded_tokens.append(f"( {group_expr} )")
+        else:
+            from ramble.workspace import RambleWorkspaceError
+
+            raise RambleWorkspaceError(
+                f"Unknown filter group '{token}' in expression '{expression}'"
+            )
+
+    return " ".join(expanded_tokens)
+
+
+def resolve_and_apply_filter_groups(args, include_where_filters):
+    """Resolve filter groups from args/env and apply them to include_where_filters"""
+    filter_group_expr = getattr(args, "filter_group", None)
+    exclude_filter_group_expr = getattr(args, "exclude_filter_group", None)
+
+    # If not specified on CLI, check environment
+    if filter_group_expr is None and exclude_filter_group_expr is None:
+        import os
+
+        active_group = os.environ.get("RAMBLE_ACTIVE_FILTER_GROUP")
+        if active_group:
+            filter_group_expr = active_group
+
+    if not filter_group_expr and not exclude_filter_group_expr:
+        return include_where_filters
+
+    filter_groups_defs = ramble.config.get("filter_groups")
+
+    combined_expr = []
+    if filter_group_expr:
+        combined_expr.append(f"( {filter_group_expr} )")
+    if exclude_filter_group_expr:
+        combined_expr.append(f"not ( {exclude_filter_group_expr} )")
+
+    final_expr = " and ".join(combined_expr)
+
+    try:
+        predicate_expr = expand_filter_groups(final_expr, filter_groups_defs)
+        if include_where_filters is None:
+            include_where_filters = []
+        include_where_filters.append([predicate_expr])
+    except RambleError as e:
+        logger.die(str(e))
+
+    return include_where_filters

--- a/lib/ramble/ramble/filters.py
+++ b/lib/ramble/ramble/filters.py
@@ -65,10 +65,22 @@ def translate_group_to_predicate(group_def: dict) -> str:
     return " and ".join(parts)
 
 
-def expand_filter_groups(expression: str, filter_groups_defs: dict) -> str:
+def expand_filter_groups(expression: str, filter_groups_defs: Optional[dict]) -> str:
     """Expand logical expression of filter groups into a predicate string"""
     if not expression:
         return "True"
+
+    if filter_groups_defs is None:
+        filter_groups_defs = {}
+
+    # Validate expression only contains allowed characters to prevent injection or silent failures
+    invalid_chars = re.sub(r"[a-zA-Z0-9_\s\(\)-]", "", expression)
+    if invalid_chars:
+        from ramble.workspace import RambleWorkspaceError
+
+        raise RambleWorkspaceError(
+            f"Invalid characters {repr(invalid_chars)} in filter group expression '{expression}'"
+        )
 
     token_re = re.compile(r"([a-zA-Z0-9_-]+|\(|\))")
     tokens = token_re.findall(expression)

--- a/lib/ramble/ramble/schema/filter_groups.py
+++ b/lib/ramble/ramble/schema/filter_groups.py
@@ -1,0 +1,42 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Schema for filter_groups configuration file.
+
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/filter_groups.py
+   :lines: 12-
+"""
+
+filter_groups_def = {
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "where": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "exclude_where": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+properties = {"filter_groups": filter_groups_def}
+
+#: Full schema with metadata
+schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Ramble filter groups configuration file schema",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": properties,
+}

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -24,6 +24,7 @@ import ramble.schema.base_system_repos
 import ramble.schema.base_workflow_manager_repos
 import ramble.schema.config
 import ramble.schema.env_vars
+import ramble.schema.filter_groups
 import ramble.schema.formatted_executables
 import ramble.schema.internals
 import ramble.schema.licenses
@@ -67,6 +68,7 @@ properties = union_dicts(
     ramble.schema.variables.properties,
     ramble.schema.variants.properties,
     ramble.schema.env_vars.properties,
+    ramble.schema.filter_groups.properties,
     ramble.schema.internals.properties,
     ramble.schema.modifiers.properties,
     ramble.schema.workflow_manager_repos.properties,

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -415,6 +415,21 @@ def test_config_add_override(mutable_empty_config):
 """
     )
 
+
+def test_config_add_override_short_scope(mutable_empty_config):
+    config("-s", "site", "add", "config:template_dirs:test1")
+    config("add", "config:template_dirs:[test2]")
+    output = config("get", "config")
+
+    assert (
+        output
+        == """config:
+  template_dirs:
+  - test2
+  - test1
+"""
+    )
+
     config("add", "config::template_dirs:[test2]")
     output = config("get", "config")
 

--- a/lib/ramble/ramble/test/cmd/filter_groups.py
+++ b/lib/ramble/ramble/test/cmd/filter_groups.py
@@ -1,0 +1,172 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.config
+import ramble.workspace
+from ramble.main import RambleCommand
+
+# Use mutable_config to isolate global configs and mutable_mock_workspace_path for workspaces
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+
+workspace_cmd = RambleCommand("workspace")
+filter_groups_cmd = RambleCommand("filter-groups")
+
+
+def test_workspace_manage_filter_groups(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    # 1. Add a filter group in workspace
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "add",
+        "-n",
+        "small-scale",
+        "-w",
+        "{n_nodes} < 4",
+        "-ew",
+        "{mpi} == 'tcp'",
+        global_args=global_args,
+    )
+
+    # Verify it was added to workspace config file
+    with open(ws.config_file_path) as f:
+        content = f.read()
+        assert "filter_groups:" in content
+        assert "small-scale:" in content
+        assert "where:" in content
+        assert "{n_nodes} < 4" in content
+        assert "exclude_where:" in content
+        assert "{mpi}" in content
+        assert "tcp" in content
+
+    # 2. List filter groups in workspace
+    out = workspace_cmd(
+        "manage",
+        "filter-groups",
+        "list",
+        global_args=global_args,
+    )
+    assert "small-scale:" in out
+    assert "{n_nodes} < 4" in out
+    assert "{mpi}" in out
+    assert "tcp" in out
+
+    # 3. Add another group in workspace
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "add",
+        "-n",
+        "large-scale",
+        "-w",
+        "{n_nodes} >= 8",
+        global_args=global_args,
+    )
+
+    # 4. Blame filter groups (should show workspace scope)
+    out = workspace_cmd(
+        "manage",
+        "filter-groups",
+        "blame",
+        global_args=global_args,
+    )
+    assert "Scope: workspace:" in out
+    assert "small-scale:" in out
+    assert "large-scale:" in out
+
+    # 5. Remove a group from workspace
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "remove",
+        "-n",
+        "small-scale",
+        global_args=global_args,
+    )
+
+    # Verify it was removed from file
+    with open(ws.config_file_path) as f:
+        content = f.read()
+        assert "small-scale:" not in content
+        assert "large-scale:" in content
+
+
+def test_global_filter_groups(workspace_name):
+    # 1. Add a global filter group (defaults to 'user' scope)
+    filter_groups_cmd(
+        "add",
+        "-n",
+        "global-small",
+        "-w",
+        "{n_nodes} < 2",
+    )
+
+    # Verify it was added to user config file
+    user_scope = ramble.config.config.scopes["user"]
+    user_config_file = user_scope.get_section_filename("filter_groups")
+
+    assert os.path.exists(user_config_file)
+    with open(user_config_file) as f:
+        content = f.read()
+        assert "filter_groups:" in content
+        assert "global-small:" in content
+        assert "{n_nodes} < 2" in content
+
+    # 2. List global filter groups
+    out = filter_groups_cmd("list")
+    assert "global-small:" in out
+    assert "{n_nodes} < 2" in out
+
+    # 3. Add a group with --scope workspace (requires active workspace)
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    filter_groups_cmd(
+        "--scope",
+        "workspace",
+        "add",
+        "-n",
+        "ws-group",
+        "-w",
+        "{n_nodes} == 4",
+        global_args=global_args,
+    )
+
+    # Verify it went to workspace config, not user config
+    with open(ws.config_file_path) as f:
+        ws_content = f.read()
+        assert "ws-group:" in ws_content
+        assert "{n_nodes} == 4" in ws_content
+
+    with open(user_config_file) as f:
+        user_content = f.read()
+        assert "ws-group:" not in user_content
+
+    # 4. Blame from top-level command
+    out = filter_groups_cmd("blame", global_args=global_args)
+    assert "Scope: user" in out
+    assert "global-small:" in out
+    assert "Scope: workspace:" in out
+    assert "ws-group:" in out
+
+    # 5. Remove global group
+    filter_groups_cmd(
+        "remove",
+        "-n",
+        "global-small",
+    )
+
+    with open(user_config_file) as f:
+        content = f.read()
+        assert "global-small:" not in content

--- a/lib/ramble/ramble/test/cmd/filter_groups.py
+++ b/lib/ramble/ramble/test/cmd/filter_groups.py
@@ -40,7 +40,7 @@ def test_workspace_manage_filter_groups(workspace_name):
     )
 
     # Verify it was added to workspace config file
-    with open(ws.config_file_path) as f:
+    with open(ws.config_file_path, encoding="utf-8") as f:
         content = f.read()
         assert "filter_groups:" in content
         assert "small-scale:" in content
@@ -96,7 +96,7 @@ def test_workspace_manage_filter_groups(workspace_name):
     )
 
     # Verify it was removed from file
-    with open(ws.config_file_path) as f:
+    with open(ws.config_file_path, encoding="utf-8") as f:
         content = f.read()
         assert "small-scale:" not in content
         assert "large-scale:" in content
@@ -117,7 +117,7 @@ def test_global_filter_groups(workspace_name):
     user_config_file = user_scope.get_section_filename("filter_groups")
 
     assert os.path.exists(user_config_file)
-    with open(user_config_file) as f:
+    with open(user_config_file, encoding="utf-8") as f:
         content = f.read()
         assert "filter_groups:" in content
         assert "global-small:" in content
@@ -144,12 +144,12 @@ def test_global_filter_groups(workspace_name):
     )
 
     # Verify it went to workspace config, not user config
-    with open(ws.config_file_path) as f:
+    with open(ws.config_file_path, encoding="utf-8") as f:
         ws_content = f.read()
         assert "ws-group:" in ws_content
         assert "{n_nodes} == 4" in ws_content
 
-    with open(user_config_file) as f:
+    with open(user_config_file, encoding="utf-8") as f:
         user_content = f.read()
         assert "ws-group:" not in user_content
 
@@ -167,7 +167,7 @@ def test_global_filter_groups(workspace_name):
         "global-small",
     )
 
-    with open(user_config_file) as f:
+    with open(user_config_file, encoding="utf-8") as f:
         content = f.read()
         assert "global-small:" not in content
 
@@ -185,6 +185,34 @@ def test_workspace_manage_filter_groups_errors(workspace_name):
 
     workspace_cmd(
         "manage", "filter-groups", "add", "-n", "foo", global_args=global_args, fail_on_error=False
+    )
+    assert workspace_cmd.returncode != 0
+
+    # Reserved keyword
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "add",
+        "-n",
+        "and",
+        "--where",
+        "x",
+        global_args=global_args,
+        fail_on_error=False,
+    )
+    assert workspace_cmd.returncode != 0
+
+    # Invalid characters
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "add",
+        "-n",
+        "foo.bar",
+        "--where",
+        "x",
+        global_args=global_args,
+        fail_on_error=False,
     )
     assert workspace_cmd.returncode != 0
 
@@ -214,6 +242,14 @@ def test_global_filter_groups_empty_list():
 
 def test_global_filter_groups_errors(workspace_name):
     filter_groups_cmd("add", "-n", "foo", fail_on_error=False)
+    assert filter_groups_cmd.returncode != 0
+
+    # Reserved keyword
+    filter_groups_cmd("add", "-n", "and", "--where", "x", fail_on_error=False)
+    assert filter_groups_cmd.returncode != 0
+
+    # Invalid characters
+    filter_groups_cmd("add", "-n", "foo.bar", "--where", "x", fail_on_error=False)
     assert filter_groups_cmd.returncode != 0
 
     filter_groups_cmd("remove", "-n", "foo", fail_on_error=False)

--- a/lib/ramble/ramble/test/cmd/filter_groups.py
+++ b/lib/ramble/ramble/test/cmd/filter_groups.py
@@ -32,9 +32,9 @@ def test_workspace_manage_filter_groups(workspace_name):
         "add",
         "-n",
         "small-scale",
-        "-w",
+        "--where",
         "{n_nodes} < 4",
-        "-ew",
+        "--exclude-where",
         "{mpi} == 'tcp'",
         global_args=global_args,
     )
@@ -69,7 +69,7 @@ def test_workspace_manage_filter_groups(workspace_name):
         "add",
         "-n",
         "large-scale",
-        "-w",
+        "--where",
         "{n_nodes} >= 8",
         global_args=global_args,
     )
@@ -108,7 +108,7 @@ def test_global_filter_groups(workspace_name):
         "add",
         "-n",
         "global-small",
-        "-w",
+        "--where",
         "{n_nodes} < 2",
     )
 
@@ -138,7 +138,7 @@ def test_global_filter_groups(workspace_name):
         "add",
         "-n",
         "ws-group",
-        "-w",
+        "--where",
         "{n_nodes} == 4",
         global_args=global_args,
     )

--- a/lib/ramble/ramble/test/cmd/filter_groups.py
+++ b/lib/ramble/ramble/test/cmd/filter_groups.py
@@ -170,3 +170,79 @@ def test_global_filter_groups(workspace_name):
     with open(user_config_file) as f:
         content = f.read()
         assert "global-small:" not in content
+
+
+def test_workspace_manage_filter_groups_empty_list(workspace_name):
+    ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+    out = workspace_cmd("manage", "filter-groups", "list", global_args=global_args)
+    assert "No filter groups defined" in out
+
+
+def test_workspace_manage_filter_groups_errors(workspace_name):
+    ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    workspace_cmd(
+        "manage", "filter-groups", "add", "-n", "foo", global_args=global_args, fail_on_error=False
+    )
+    assert workspace_cmd.returncode != 0
+
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "remove",
+        "-n",
+        "foo",
+        global_args=global_args,
+        fail_on_error=False,
+    )
+    assert workspace_cmd.returncode != 0
+
+    workspace_cmd(
+        "manage", "filter-groups", "add", "-n", "foo", "--where", "x", global_args=global_args
+    )
+    workspace_cmd(
+        "manage", "filter-groups", "add", "-n", "foo", "--where", "y", global_args=global_args
+    )
+
+
+def test_global_filter_groups_empty_list():
+    out = filter_groups_cmd("list")
+    assert "No filter groups defined" in out
+
+
+def test_global_filter_groups_errors(workspace_name):
+    filter_groups_cmd("add", "-n", "foo", fail_on_error=False)
+    assert filter_groups_cmd.returncode != 0
+
+    filter_groups_cmd("remove", "-n", "foo", fail_on_error=False)
+    assert filter_groups_cmd.returncode != 0
+
+    filter_groups_cmd("add", "-n", "foo", "--where", "x")
+    filter_groups_cmd("add", "-n", "foo", "--where", "y")
+
+    filter_groups_cmd("add", "-n", "bar", "--exclude-where", "z")
+    out = filter_groups_cmd("list")
+    assert "exclude_where:" in out
+    assert "z" in out
+
+    out = filter_groups_cmd("blame")
+    assert "exclude_where:" in out
+
+    filter_groups_cmd("--scope", "workspace", "list", fail_on_error=False)
+    assert filter_groups_cmd.returncode != 0
+
+    ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+    filter_groups_cmd(
+        "--scope", "workspace", "add", "-n", "ws-foo", "--where", "x", global_args=global_args
+    )
+    filter_groups_cmd("--scope", "workspace", "remove", "-n", "ws-foo", global_args=global_args)
+
+
+def test_global_filter_groups_no_subcommand(capsys):
+    with pytest.raises(SystemExit):
+        filter_groups_cmd()
+    captured = capsys.readouterr()
+    assert "the following arguments are required: ACTION" in captured.err

--- a/lib/ramble/ramble/test/cmd/filter_groups.py
+++ b/lib/ramble/ramble/test/cmd/filter_groups.py
@@ -55,6 +55,7 @@ def test_workspace_manage_filter_groups(workspace_name):
         "manage",
         "filter-groups",
         "list",
+        "-v",
         global_args=global_args,
     )
     assert "small-scale:" in out
@@ -81,7 +82,7 @@ def test_workspace_manage_filter_groups(workspace_name):
         "blame",
         global_args=global_args,
     )
-    assert "Scope: workspace:" in out
+    assert ws.config_file_path in out
     assert "small-scale:" in out
     assert "large-scale:" in out
 
@@ -124,7 +125,7 @@ def test_global_filter_groups(workspace_name):
         assert "{n_nodes} < 2" in content
 
     # 2. List global filter groups
-    out = filter_groups_cmd("list")
+    out = filter_groups_cmd("list", "-v")
     assert "global-small:" in out
     assert "{n_nodes} < 2" in out
 
@@ -155,10 +156,9 @@ def test_global_filter_groups(workspace_name):
 
     # 4. Blame from top-level command
     out = filter_groups_cmd("blame", global_args=global_args)
-    assert "Scope: user" in out
-    assert "global-small:" in out
-    assert "Scope: workspace:" in out
-    assert "ws-group:" in out
+    assert ws.config_file_path in out
+    assert "global-small" in out
+    assert "ws-group" in out
 
     # 5. Remove global group
     filter_groups_cmd(
@@ -259,7 +259,7 @@ def test_global_filter_groups_errors(workspace_name):
     filter_groups_cmd("add", "-n", "foo", "--where", "y")
 
     filter_groups_cmd("add", "-n", "bar", "--exclude-where", "z")
-    out = filter_groups_cmd("list")
+    out = filter_groups_cmd("list", "-v")
     assert "exclude_where:" in out
     assert "z" in out
 
@@ -282,3 +282,162 @@ def test_global_filter_groups_no_subcommand(capsys):
         filter_groups_cmd()
     captured = capsys.readouterr()
     assert "the following arguments are required: ACTION" in captured.err
+
+
+def test_workspace_manage_filter_groups_scopes(workspace_name):
+    ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    # Add global (user scope) filter group using workspace manage filter-groups
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "--scope",
+        "user",
+        "add",
+        "-n",
+        "user-fg",
+        "--where",
+        "y",
+        global_args=global_args,
+    )
+
+    # Add workspace scope filter group
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "--scope",
+        "workspace",
+        "add",
+        "-n",
+        "ws-fg",
+        "--where",
+        "x",
+        global_args=global_args,
+    )
+
+    # List all scopes (no scope specified)
+    out = workspace_cmd(
+        "manage",
+        "filter-groups",
+        "list",
+        global_args=global_args,
+    )
+    assert "user" in out
+    assert "user-fg" in out
+    assert "workspace" in out
+    assert "ws-fg" in out
+
+    # List only user scope
+    out_user = workspace_cmd(
+        "manage",
+        "filter-groups",
+        "--scope",
+        "user",
+        "list",
+        global_args=global_args,
+    )
+    assert "user-fg" in out_user
+    assert "ws-fg" not in out_user
+
+    # Remove user scope filter group
+    workspace_cmd(
+        "manage",
+        "filter-groups",
+        "--scope",
+        "user",
+        "remove",
+        "-n",
+        "user-fg",
+        global_args=global_args,
+    )
+
+    # Verify removed
+    out_user_after = workspace_cmd(
+        "manage",
+        "filter-groups",
+        "--scope",
+        "user",
+        "list",
+        global_args=global_args,
+    )
+    assert "No filter groups defined in scope 'user'" in out_user_after
+
+
+def test_filter_groups_precedence_overwrite(workspace_name):
+    # 1. Create workspace
+    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.activate(ws)
+
+    try:
+        # 2. Add a filter group to user scope
+        filter_groups_cmd(
+            "--scope",
+            "user",
+            "add",
+            "-n",
+            "test-precedence",
+            "--where",
+            "{n_nodes} == 16",
+        )
+
+        # 3. Add same filter group to workspace scope
+        filter_groups_cmd(
+            "--scope",
+            "workspace",
+            "add",
+            "-n",
+            "test-precedence",
+            "--where",
+            "{n_nodes} == 42",
+        )
+
+        # 4. Get the merged filter groups
+        fg = ramble.config.get("filter_groups")
+        assert "test-precedence" in fg
+        # The list in 'where' should only contain '{n_nodes} == 42',
+        # NOT ['{n_nodes} == 42', '{n_nodes} == 16']
+        assert fg["test-precedence"]["where"] == ["{n_nodes} == 42"]
+    finally:
+        ramble.workspace.deactivate()
+
+
+def test_empty_filter_group_behavior(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.activate(ws)
+    global_args = ["-w", workspace_name]
+
+    try:
+        # Set an empty filter group directly in the workspace config
+        with ws.write_transaction():
+            ramble.config.set("filter_groups:empty-fg", {}, scope=ws.ws_file_config_scope_name())
+
+        # Verify that we can update it (add elements) and it logs "Updating existing filter group"
+        out = workspace_cmd(
+            "manage",
+            "filter-groups",
+            "add",
+            "-n",
+            "empty-fg",
+            "--where",
+            "{n_nodes} < 4",
+            global_args=global_args,
+        )
+        assert "Updating existing filter group 'empty-fg'" in out
+
+        # Reset it to empty
+        with ws.write_transaction():
+            ramble.config.set("filter_groups:empty-fg", {}, scope=ws.ws_file_config_scope_name())
+
+        # Try removing it. It should succeed and print "Removing filter group"
+        out = workspace_cmd(
+            "manage",
+            "filter-groups",
+            "remove",
+            "-n",
+            "empty-fg",
+            global_args=global_args,
+        )
+        assert "Removing filter group 'empty-fg'" in out
+    finally:
+        ramble.workspace.deactivate()

--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -128,3 +128,79 @@ exit 0
             text=True,
             check=False,
         )
+
+
+@pytest.mark.parametrize("shell", _SHELLS_TO_TEST)
+def test_shell_wrapper_workspace_filter_group(shell, tmpdir):
+    """Test workspace activation with filter group and deactivation."""
+    if not shutil.which(shell):
+        pytest.skip(f"{shell} not found")
+
+    setup_env = os.path.join(paths.ramble_root, "share", "ramble", _SETUP_ENV_FILE[shell])
+    test_script_path = str(tmpdir.join(f"test_fg.{shell}"))
+    ws_name = f"test_ws_fg_{shell}"
+
+    script_templates = {
+        "bash": f"""
+source "{setup_env}"
+ramble workspace create {ws_name} || exit 1
+ramble -w {ws_name} workspace manage filter-groups add -n foo -w "n_nodes == 1" || exit 2
+ramble workspace activate {ws_name} -fg foo || exit 3
+if [ "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo" ]; then exit 4; fi
+ramble workspace deactivate || exit 5
+if [ ! -z ${{RAMBLE_ACTIVE_FILTER_GROUP+x}} ]; then exit 6; fi
+exit 0
+""",
+        "tcsh": f"""
+set prompt=""
+source "{setup_env}"
+ramble workspace create {ws_name}
+if ( $status != 0 ) exit 1
+ramble -w {ws_name} workspace manage filter-groups add -n foo -w "n_nodes == 1"
+if ( $status != 0 ) exit 2
+ramble workspace activate {ws_name} -fg foo
+if ( $status != 0 ) exit 3
+if ( "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo" ) exit 4
+ramble workspace deactivate
+if ( $status != 0 ) exit 5
+if ( $?RAMBLE_ACTIVE_FILTER_GROUP ) exit 6
+exit 0
+""",
+        "fish": f"""
+source "{setup_env}"
+ramble workspace create {ws_name}; or exit 1
+ramble -w {ws_name} workspace manage filter-groups add -n foo -w "n_nodes == 1"; or exit 2
+ramble workspace activate {ws_name} -fg foo; or exit 3
+if test "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo"; exit 4; end
+ramble workspace deactivate; or exit 5
+if set -q RAMBLE_ACTIVE_FILTER_GROUP; exit 6; end
+exit 0
+""",
+    }
+    script_content = script_templates[shell]
+
+    with open(test_script_path, "w") as f:
+        f.write(script_content)
+
+    try:
+        cmd = [shell, test_script_path]
+        process = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(tmpdir),
+            env=os.environ.copy(),
+            check=False,
+        )
+        if process.returncode != 0:
+            print(process.stdout)
+            print(process.stderr)
+        assert process.returncode == 0
+    finally:
+        ramble_exe = os.path.join(paths.ramble_root, "bin", "ramble")
+        subprocess.run(
+            [ramble_exe, "workspace", "rm", "-y", ws_name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )

--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -145,7 +145,17 @@ def test_shell_wrapper_workspace_filter_group(shell, tmpdir):
 source "{setup_env}"
 ramble workspace create {ws_name} || exit 1
 ramble -w {ws_name} workspace manage filter-groups add -n foo --where "n_nodes == 1" || exit 2
-ramble workspace activate {ws_name} -fg foo || exit 3
+ramble workspace activate {ws_name} --fg foo || exit 3
+if [ "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo" ]; then exit 4; fi
+ramble workspace deactivate || exit 5
+if [ ! -z ${{RAMBLE_ACTIVE_FILTER_GROUP+x}} ]; then exit 6; fi
+exit 0
+""",
+        "zsh": f"""
+source "{setup_env}"
+ramble workspace create {ws_name} || exit 1
+ramble -w {ws_name} workspace manage filter-groups add -n foo --where "n_nodes == 1" || exit 2
+ramble workspace activate {ws_name} --fg foo || exit 3
 if [ "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo" ]; then exit 4; fi
 ramble workspace deactivate || exit 5
 if [ ! -z ${{RAMBLE_ACTIVE_FILTER_GROUP+x}} ]; then exit 6; fi
@@ -158,7 +168,7 @@ ramble workspace create {ws_name}
 if ( $status != 0 ) exit 1
 ramble -w {ws_name} workspace manage filter-groups add -n foo --where "n_nodes == 1"
 if ( $status != 0 ) exit 2
-ramble workspace activate {ws_name} -fg foo
+ramble workspace activate {ws_name} --fg foo
 if ( $status != 0 ) exit 3
 if ( "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo" ) exit 4
 ramble workspace deactivate
@@ -170,7 +180,7 @@ exit 0
 source "{setup_env}"
 ramble workspace create {ws_name}; or exit 1
 ramble -w {ws_name} workspace manage filter-groups add -n foo --where "n_nodes == 1"; or exit 2
-ramble workspace activate {ws_name} -fg foo; or exit 3
+ramble workspace activate {ws_name} --fg foo; or exit 3
 if test "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo"; exit 4; end
 ramble workspace deactivate; or exit 5
 if set -q RAMBLE_ACTIVE_FILTER_GROUP; exit 6; end

--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -144,7 +144,7 @@ def test_shell_wrapper_workspace_filter_group(shell, tmpdir):
         "bash": f"""
 source "{setup_env}"
 ramble workspace create {ws_name} || exit 1
-ramble -w {ws_name} workspace manage filter-groups add -n foo -w "n_nodes == 1" || exit 2
+ramble -w {ws_name} workspace manage filter-groups add -n foo --where "n_nodes == 1" || exit 2
 ramble workspace activate {ws_name} -fg foo || exit 3
 if [ "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo" ]; then exit 4; fi
 ramble workspace deactivate || exit 5
@@ -156,7 +156,7 @@ set prompt=""
 source "{setup_env}"
 ramble workspace create {ws_name}
 if ( $status != 0 ) exit 1
-ramble -w {ws_name} workspace manage filter-groups add -n foo -w "n_nodes == 1"
+ramble -w {ws_name} workspace manage filter-groups add -n foo --where "n_nodes == 1"
 if ( $status != 0 ) exit 2
 ramble workspace activate {ws_name} -fg foo
 if ( $status != 0 ) exit 3
@@ -169,7 +169,7 @@ exit 0
         "fish": f"""
 source "{setup_env}"
 ramble workspace create {ws_name}; or exit 1
-ramble -w {ws_name} workspace manage filter-groups add -n foo -w "n_nodes == 1"; or exit 2
+ramble -w {ws_name} workspace manage filter-groups add -n foo --where "n_nodes == 1"; or exit 2
 ramble workspace activate {ws_name} -fg foo; or exit 3
 if test "$RAMBLE_ACTIVE_FILTER_GROUP" != "foo"; exit 4; end
 ramble workspace deactivate; or exit 5

--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -179,7 +179,7 @@ exit 0
     }
     script_content = script_templates[shell]
 
-    with open(test_script_path, "w") as f:
+    with open(test_script_path, "w", encoding="utf-8") as f:
         f.write(script_content)
 
     try:

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -169,6 +169,11 @@ def build_variant_set():
         ("1_01", "1_01", set(), 1),
         ("0x10", "0x10", set(), 1),
         ("{application_name}-1_01", "foo-1_01", set(), 1),
+        ('not ("a" == "a")', "False", set(), 1),
+        ('not ("a" == "b")', "True", set(), 1),
+        ('not ("SETUP" == "SUCCESS")', "True", set(), 1),
+        ('("SETUP" == "FAILED") and not ("SETUP" == "SUCCESS")', "False", set(), 1),
+        ('("SETUP" == "SETUP") and not ("SETUP" == "SUCCESS")', "True", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):
@@ -231,6 +236,11 @@ def test_expansions(input, output, no_expand_vars, passes):
         ("randint(3, 3)", 3, set(), 1),
         ("~0", -1, set(), 1),
         ("~2", -3, set(), 1),
+        ('not ("a" == "a")', False, set(), 1),
+        ('not ("a" == "b")', True, set(), 1),
+        ('not ("SETUP" == "SUCCESS")', True, set(), 1),
+        ('("SETUP" == "FAILED") and not ("SETUP" == "SUCCESS")', False, set(), 1),
+        ('("SETUP" == "SETUP") and not ("SETUP" == "SUCCESS")', True, set(), 1),
     ],
 )
 def test_typed_expansions(input, output, no_expand_vars, passes):

--- a/lib/ramble/ramble/test/filters.py
+++ b/lib/ramble/ramble/test/filters.py
@@ -82,3 +82,75 @@ def test_expand_filter_groups():
     assert ramble.filters.expand_filter_groups("", None) == "True"
     with pytest.raises(RambleWorkspaceError):
         ramble.filters.expand_filter_groups("small-scale", None)
+
+
+def test_translate_group_to_predicate_empty_lists():
+    # Test group with empty lists (should return "True" at line 54)
+    group_empty_lists = {"where": [], "exclude_where": []}
+    assert ramble.filters.translate_group_to_predicate(group_empty_lists) == "True"
+
+
+def test_resolve_and_apply_filter_groups(mutable_config):
+    class MockArgs:
+        def __init__(self, filter_group=None, exclude_filter_group=None):
+            self.filter_group = filter_group
+            self.exclude_filter_group = exclude_filter_group
+
+    # Mock filter groups in config
+    ramble.config.set(
+        "filter_groups",
+        {"small": {"where": ["{n_nodes} < 4"]}, "tcp": {"exclude_where": ["{mpi} != 'tcp'"]}},
+        scope="user",
+    )
+
+    # Case 1: Neither CLI nor Env
+    assert ramble.filters.resolve_and_apply_filter_groups(MockArgs(), None) is None
+    assert ramble.filters.resolve_and_apply_filter_groups(MockArgs(), [["existing"]]) == [
+        ["existing"]
+    ]
+
+    # Case 2: CLI --filter-group
+    args = MockArgs(filter_group="small")
+    res = ramble.filters.resolve_and_apply_filter_groups(args, None)
+    assert len(res) == 1
+    assert "small" in res[0][0] or "{n_nodes}" in res[0][0]
+
+    # Case 3: CLI --exclude-filter-group
+    args = MockArgs(exclude_filter_group="tcp")
+    res = ramble.filters.resolve_and_apply_filter_groups(args, None)
+    assert len(res) == 1
+    assert "not ( ( (not ({mpi} != 'tcp')) ) )" in res[0][0]
+
+    # Case 4: Both CLI
+    args = MockArgs(filter_group="small", exclude_filter_group="tcp")
+    res = ramble.filters.resolve_and_apply_filter_groups(args, None)
+    assert len(res) == 1
+    assert "( ( (({n_nodes} < 4)) ) ) and not ( ( (not ({mpi} != 'tcp')) ) )" in res[0][0]
+
+    # Case 5: Env var only
+    import os
+
+    os.environ["RAMBLE_ACTIVE_FILTER_GROUP"] = "small"
+    try:
+        args = MockArgs()
+        res = ramble.filters.resolve_and_apply_filter_groups(args, None)
+        assert len(res) == 1
+        assert "small" in res[0][0] or "{n_nodes}" in res[0][0]
+    finally:
+        del os.environ["RAMBLE_ACTIVE_FILTER_GROUP"]
+
+    # Case 6: CLI overrides Env var
+    os.environ["RAMBLE_ACTIVE_FILTER_GROUP"] = "small"
+    try:
+        args = MockArgs(filter_group="tcp")
+        res = ramble.filters.resolve_and_apply_filter_groups(args, None)
+        assert len(res) == 1
+        assert "tcp" in res[0][0] or "{mpi}" in res[0][0]
+        assert "small" not in res[0][0] and "{n_nodes}" not in res[0][0]
+    finally:
+        del os.environ["RAMBLE_ACTIVE_FILTER_GROUP"]
+
+    # Case 7: Failure path (invalid group)
+    args = MockArgs(filter_group="invalid")
+    with pytest.raises(SystemExit):
+        ramble.filters.resolve_and_apply_filter_groups(args, None)

--- a/lib/ramble/ramble/test/filters.py
+++ b/lib/ramble/ramble/test/filters.py
@@ -9,7 +9,7 @@
 import pytest
 
 import ramble.filters
-from ramble.workspace import RambleWorkspaceError
+from ramble.error import RambleError
 
 
 def test_translate_group_to_predicate():
@@ -71,16 +71,16 @@ def test_expand_filter_groups():
     )
 
     # Test invalid group
-    with pytest.raises(RambleWorkspaceError):
+    with pytest.raises(RambleError):
         ramble.filters.expand_filter_groups("invalid-group", filter_groups_defs)
 
     # Test invalid characters
-    with pytest.raises(RambleWorkspaceError):
+    with pytest.raises(RambleError):
         ramble.filters.expand_filter_groups("small-scale & tcp-only", filter_groups_defs)
 
     # Test None defs
     assert ramble.filters.expand_filter_groups("", None) == "True"
-    with pytest.raises(RambleWorkspaceError):
+    with pytest.raises(RambleError):
         ramble.filters.expand_filter_groups("small-scale", None)
 
 
@@ -154,3 +154,27 @@ def test_resolve_and_apply_filter_groups(mutable_config):
     args = MockArgs(filter_group="invalid")
     with pytest.raises(SystemExit):
         ramble.filters.resolve_and_apply_filter_groups(args, None)
+
+
+def test_validate_filter_group_name():
+    # Test valid names
+    ramble.filters.validate_filter_group_name("small")
+    ramble.filters.validate_filter_group_name("small-scale")
+    ramble.filters.validate_filter_group_name("small_scale")
+    ramble.filters.validate_filter_group_name("group-1")
+
+    # Test reserved keywords (should fail)
+    with pytest.raises(RambleError):
+        ramble.filters.validate_filter_group_name("and")
+    with pytest.raises(RambleError):
+        ramble.filters.validate_filter_group_name("OR")
+    with pytest.raises(RambleError):
+        ramble.filters.validate_filter_group_name("not")
+
+    # Test invalid characters (should fail)
+    with pytest.raises(RambleError):
+        ramble.filters.validate_filter_group_name("small scale")
+    with pytest.raises(RambleError):
+        ramble.filters.validate_filter_group_name("small.scale")
+    with pytest.raises(RambleError):
+        ramble.filters.validate_filter_group_name("small&scale")

--- a/lib/ramble/ramble/test/filters.py
+++ b/lib/ramble/ramble/test/filters.py
@@ -1,0 +1,84 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.filters
+from ramble.workspace import RambleWorkspaceError
+
+
+def test_translate_group_to_predicate():
+    # Test empty group
+    assert ramble.filters.translate_group_to_predicate({}) == "True"
+    assert ramble.filters.translate_group_to_predicate(None) == "True"
+
+    # Test only where
+    group_only_where = {"where": ["{n_nodes} < 4", "{workload} == 'foo'"]}
+    assert (
+        ramble.filters.translate_group_to_predicate(group_only_where)
+        == "(({n_nodes} < 4) and ({workload} == 'foo'))"
+    )
+
+    # Test only exclude_where
+    group_only_exclude = {"exclude_where": ["{mpi} == 'tcp'", "{platform} == 'bar'"]}
+    assert (
+        ramble.filters.translate_group_to_predicate(group_only_exclude)
+        == "(not ({mpi} == 'tcp') and not ({platform} == 'bar'))"
+    )
+
+    # Test both
+    group_both = {"where": ["{n_nodes} < 4"], "exclude_where": ["{mpi} == 'tcp'"]}
+    assert (
+        ramble.filters.translate_group_to_predicate(group_both)
+        == "(({n_nodes} < 4)) and (not ({mpi} == 'tcp'))"
+    )
+
+
+def test_expand_filter_groups():
+    filter_groups_defs = {
+        "small-scale": {"where": ["{n_nodes} < 4"]},
+        "single-node": {"where": ["{n_nodes} == 1"]},
+        "tcp-only": {"exclude_where": ["{mpi} != 'tcp'"]},
+    }
+
+    # Test empty expression
+    assert ramble.filters.expand_filter_groups("", filter_groups_defs) == "True"
+    assert ramble.filters.expand_filter_groups(None, filter_groups_defs) == "True"
+
+    # Test single group
+    assert (
+        ramble.filters.expand_filter_groups("small-scale", filter_groups_defs)
+        == "( (({n_nodes} < 4)) )"
+    )
+
+    # Test logical expression
+    assert (
+        ramble.filters.expand_filter_groups("small-scale and not single-node", filter_groups_defs)
+        == "( (({n_nodes} < 4)) ) and not ( (({n_nodes} == 1)) )"
+    )
+
+    # Test parentheses
+    assert (
+        ramble.filters.expand_filter_groups(
+            "(small-scale or tcp-only) and not single-node", filter_groups_defs
+        )
+        == "( ( (({n_nodes} < 4)) ) or ( (not ({mpi} != 'tcp')) ) ) and not ( (({n_nodes} == 1)) )"
+    )
+
+    # Test invalid group
+    with pytest.raises(RambleWorkspaceError):
+        ramble.filters.expand_filter_groups("invalid-group", filter_groups_defs)
+
+    # Test invalid characters
+    with pytest.raises(RambleWorkspaceError):
+        ramble.filters.expand_filter_groups("small-scale & tcp-only", filter_groups_defs)
+
+    # Test None defs
+    assert ramble.filters.expand_filter_groups("", None) == "True"
+    with pytest.raises(RambleWorkspaceError):
+        ramble.filters.expand_filter_groups("small-scale", None)

--- a/lib/ramble/ramble/workspace/shell.py
+++ b/lib/ramble/ramble/workspace/shell.py
@@ -13,12 +13,14 @@ from ramble.util.colors import colorize
 from spack.util.environment import EnvironmentModifications
 
 
-def activate_header(ws, shell, prompt=None):
+def activate_header(ws, shell, prompt=None, filter_group=None):
     # Construct the commands to run
     cmds = ""
     if shell == "csh":
         # TODO: figure out how to make color work for csh
         cmds += f"setenv {ramble.workspace.RAMBLE_WORKSPACE_VAR} {ws.root};\n"
+        if filter_group:
+            cmds += f"setenv RAMBLE_ACTIVE_FILTER_GROUP {filter_group};\n"
         if prompt:
             cmds += "if (! $?RAMBLE_OLD_PROMPT ) "
             cmds += 'setenv RAMBLE_OLD_PROMPT "${prompt}";\n'
@@ -28,6 +30,8 @@ def activate_header(ws, shell, prompt=None):
             prompt = colorize("@G{%s} " % prompt, color=True)
 
         cmds += f"set -gx {ramble.workspace.RAMBLE_WORKSPACE_VAR} {ws.root};\n"
+        if filter_group:
+            cmds += f"set -gx RAMBLE_ACTIVE_FILTER_GROUP {filter_group};\n"
         #
         # NOTE: We're not changing the fish_prompt function (which is fish's
         # solution to the PS1 variable) here. This is a bit fiddly, and easy to
@@ -36,12 +40,16 @@ def activate_header(ws, shell, prompt=None):
     elif shell == "bat":
         # TODO: Color
         cmds += f'set "{ramble.workspace.RAMBLE_WORKSPACE_VAR}={ws.root}"\n'
+        if filter_group:
+            cmds += f'set "RAMBLE_ACTIVE_FILTER_GROUP={filter_group}"\n'
         # TODO: prompt
     else:
         if "color" in os.getenv("TERM", "") and prompt:
             prompt = colorize("@G{%s}" % prompt, color=True)
 
         cmds += f"export {ramble.workspace.RAMBLE_WORKSPACE_VAR}={ws.root};\n"
+        if filter_group:
+            cmds += f"export RAMBLE_ACTIVE_FILTER_GROUP={filter_group};\n"
         if prompt:
             cmds += "if [ -z ${RAMBLE_OLD_PS1+x} ]; then\n"
             cmds += "    if [ -z ${PS1+x} ]; then\n"
@@ -58,17 +66,20 @@ def deactivate_header(shell):
     cmds = ""
     if shell == "csh":
         cmds += f"unsetenv {ramble.workspace.RAMBLE_WORKSPACE_VAR};\n"
+        cmds += "if ( $?RAMBLE_ACTIVE_FILTER_GROUP ) unsetenv RAMBLE_ACTIVE_FILTER_GROUP;\n"
         cmds += "if ( $?RAMBLE_OLD_PROMPT ) "
         cmds += '    eval \'set prompt="$RAMBLE_OLD_PROMPT" &&'
         cmds += "        unsetenv RAMBLE_OLD_PROMPT';\n"
     elif shell == "fish":
         cmds += f"set -e {ramble.workspace.RAMBLE_WORKSPACE_VAR};\n"
+        cmds += "set -e RAMBLE_ACTIVE_FILTER_GROUP;\n"
         #
         # NOTE: Not changing fish_prompt (above) => no need to restore it here.
         #
     elif shell == "bat":
         # TODO: Color
         cmds += f'set "{ramble.workspace.RAMBLE_WORKSPACE_VAR}="\n'
+        cmds += 'set "RAMBLE_ACTIVE_FILTER_GROUP="\n'
         # TODO: despacktivate
         # TODO: prompt
     else:
@@ -77,6 +88,9 @@ def deactivate_header(shell):
             ramble.workspace.RAMBLE_WORKSPACE_VAR,
             ramble.workspace.RAMBLE_WORKSPACE_VAR,
         )
+        cmds += "fi;\n"
+        cmds += "if [ ! -z ${RAMBLE_ACTIVE_FILTER_GROUP+x} ]; then\n"
+        cmds += "    unset RAMBLE_ACTIVE_FILTER_GROUP; export RAMBLE_ACTIVE_FILTER_GROUP;\n"
         cmds += "fi;\n"
         cmds += "if [ ! -z ${RAMBLE_OLD_PS1+x} ]; then\n"
         cmds += "    if [ \"$RAMBLE_OLD_PS1\" = '$$$$' ]; then\n"

--- a/lib/ramble/ramble/workspace/shell.py
+++ b/lib/ramble/ramble/workspace/shell.py
@@ -72,7 +72,7 @@ def deactivate_header(shell):
         cmds += "        unsetenv RAMBLE_OLD_PROMPT';\n"
     elif shell == "fish":
         cmds += f"set -e {ramble.workspace.RAMBLE_WORKSPACE_VAR};\n"
-        cmds += "set -e RAMBLE_ACTIVE_FILTER_GROUP;\n"
+        cmds += "if set -q RAMBLE_ACTIVE_FILTER_GROUP; set -e RAMBLE_ACTIVE_FILTER_GROUP; end;\n"
         #
         # NOTE: Not changing fish_prompt (above) => no need to restore it here.
         #

--- a/share/ramble/csh/ramble.csh
+++ b/share/ramble/csh/ramble.csh
@@ -29,7 +29,7 @@ end
 
 # h and V flags don't require further output parsing.
 if ( "$_rmb_flags" =~ *h* || "$_rmb_flags" =~ *V* ) then
-    \ramble $_rmb_flags $_rmb_args
+    \ramble $_rmb_flags $_rmb_args:q
     set _rmb_rs = $status
     goto _rmb_end
 endif
@@ -72,12 +72,12 @@ case workspace:
                      "$_rmb_args" =~ "* -h*" || \
                      "$_rmb_args" =~ "* --help*" ) then
                     # No args or args contain --sh, --csh, or -h/--help: just execute.
-                    \ramble $_rmb_flags workspace $_rmb_args
+                    \ramble $_rmb_flags workspace $_rmb_args:q
                     set _rmb_rs = $status
                 else
                     shift _rmb_args  # consume 'activate' or 'deactivate'
                     # Actual call to activate: source the output.
-                    set _activate_cmd = `\ramble $_rmb_flags workspace activate --csh $_rmb_args`
+                    set _activate_cmd = `\ramble $_rmb_flags workspace activate --csh $_rmb_args:q`
                     set _rmb_rs = $status
                     eval "$_activate_cmd"
                 endif
@@ -93,7 +93,7 @@ case workspace:
                 if ( "$_rmb_args" =~ "* --sh*" || \
                      "$_rmb_args" =~ "* --csh*" ) then
                     # Args contain --sh or --csh: just execute.
-                    \ramble $_rmb_flags workspace $_rmb_args
+                    \ramble $_rmb_flags workspace $_rmb_args:q
                     set _rmb_rs = $status
                 else if ( "$_rmb_env_arg" != "" ) then
                     # Any other arguments are an error or -h/--help: just run help.
@@ -110,7 +110,7 @@ case workspace:
                 if ( "$_rmb_args" =~ *" -a"* || \
                      "$_rmb_args" =~ *" --activate"* ) then
                     # Args contain activate flag
-                    set _create_activate_cmd = `\ramble $_rmb_flags workspace $_rmb_args`
+                    set _create_activate_cmd = `\ramble $_rmb_flags workspace $_rmb_args:q`
                     set _rmb_rs = $status
                     if ( $_rmb_rs == 0 ) then
                         eval "$_create_activate_cmd"
@@ -118,12 +118,12 @@ case workspace:
                         echo "==> Created and activated workspace in $_ws"
                     endif
                 else
-                    \ramble $_rmb_flags workspace $_rmb_args
+                    \ramble $_rmb_flags workspace $_rmb_args:q
                     set _rmb_rs = $status
                 endif
                 breaksw
             default:
-                \ramble $_rmb_flags workspace $_rmb_args
+                \ramble $_rmb_flags workspace $_rmb_args:q
                 set _rmb_rs = $status
                 breaksw
         endsw
@@ -131,7 +131,7 @@ case workspace:
     breaksw
 
 default:
-    \ramble $_rmb_flags $_rmb_args
+    \ramble $_rmb_flags $_rmb_args:q
     set _rmb_rs = $status
     breaksw
 endsw

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -436,7 +436,7 @@ _ramble_filter_groups() {
 }
 
 _ramble_filter_groups_add() {
-    RAMBLE_COMPREPLY="-h --help -n --name -w --where -ew --exclude-where"
+    RAMBLE_COMPREPLY="-h --help -n --name --where --exclude-where"
 }
 
 _ramble_filter_groups_remove() {
@@ -782,7 +782,7 @@ _ramble_workspace_manage_filter_groups() {
 }
 
 _ramble_workspace_manage_filter_groups_add() {
-    RAMBLE_COMPREPLY="-h --help -n --name -w --where -ew --exclude-where"
+    RAMBLE_COMPREPLY="-h --help -n --name --where --exclude-where"
 }
 
 _ramble_workspace_manage_filter_groups_remove() {

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -268,7 +268,7 @@ _ramble() {
     then
         RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -A --aggregate-warnings -S --suppress-warnings -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo --resolve-variables-in-subprocesses -k --insecure -l --enable-locks -L --disable-locks -m --mock --overwrite-inventories --mock-applications --mock-modifiers --mock-package-managers --mock-workflow-managers --mock-systems --mock-platforms --mock-base-classes --mock-base-applications --mock-base-modifiers --mock-base-package-managers --mock-base-workflow-managers --mock-base-systems --mock-base-platforms -p --profile --sorted-profile --lines --profile-restrictions -v --verbose --stacktrace -V --version"
     else
-        RAMBLE_COMPREPLY="attributes clean commands config data debug deployment docs edit help info license list mirror on python repo results software-definitions style unit-test workspace"
+        RAMBLE_COMPREPLY="attributes clean commands config data debug deployment docs edit filter-groups help info license list mirror on python repo results software-definitions style unit-test workspace"
     fi
 }
 
@@ -406,7 +406,7 @@ _ramble_deployment() {
 }
 
 _ramble_deployment_push() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --deployment-name -d --upload-url -u --phases --include-phase-dependencies --where --exclude-where --filter-tags"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --deployment-name -d --upload-url -u --phases --include-phase-dependencies --where --exclude-where --filter-tags -fg --filter-group -efg --exclude-filter-group"
 }
 
 _ramble_deployment_pull() {
@@ -424,6 +424,31 @@ _ramble_edit() {
     else
         RAMBLE_COMPREPLY=""
     fi
+}
+
+_ramble_filter_groups() {
+    if $list_options
+    then
+        RAMBLE_COMPREPLY="-h --help --scope"
+    else
+        RAMBLE_COMPREPLY="add remove list blame"
+    fi
+}
+
+_ramble_filter_groups_add() {
+    RAMBLE_COMPREPLY="-h --help -n --name -w --where -ew --exclude-where"
+}
+
+_ramble_filter_groups_remove() {
+    RAMBLE_COMPREPLY="-h --help -n --name"
+}
+
+_ramble_filter_groups_list() {
+    RAMBLE_COMPREPLY="-h --help"
+}
+
+_ramble_filter_groups_blame() {
+    RAMBLE_COMPREPLY="-h --help"
 }
 
 _ramble_help() {
@@ -519,7 +544,7 @@ _ramble_mirror_list() {
 }
 
 _ramble_on() {
-    RAMBLE_COMPREPLY="-h --help --executor --enable-per-experiment-prints --suppress-run-header --where --exclude-where --filter-tags"
+    RAMBLE_COMPREPLY="-h --help --executor --enable-per-experiment-prints --suppress-run-header --where --exclude-where --filter-tags -fg --filter-group -efg --exclude-filter-group"
 }
 
 _ramble_python() {
@@ -631,7 +656,7 @@ _ramble_workspace() {
 _ramble_workspace_activate() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat -p --prompt --temp -d --dir --parent-dir --dry-run"
+        RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat -p --prompt --temp -d --dir --parent-dir --dry-run -fg --filter-group"
     else
         _workspaces
     fi
@@ -663,11 +688,11 @@ _ramble_workspace_config() {
 }
 
 _ramble_workspace_setup() {
-    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output"
+    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output -fg --filter-group -efg --exclude-filter-group"
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output --dry-run"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output --dry-run -fg --filter-group -efg --exclude-filter-group"
 }
 
 _ramble_workspace_push_to_cache() {
@@ -722,7 +747,7 @@ _ramble_workspace_manage() {
     then
         RAMBLE_COMPREPLY="-h --help --dry-run"
     else
-        RAMBLE_COMPREPLY="experiments software includes modifiers"
+        RAMBLE_COMPREPLY="experiments software includes modifiers filter-groups"
     fi
 }
 
@@ -745,4 +770,29 @@ _ramble_workspace_manage_includes() {
 
 _ramble_workspace_manage_modifiers() {
     RAMBLE_COMPREPLY="-h --help --list -l --add --remove --mod-index -i --scope -s --name -n --mode -m --on-executable -e --dry-run"
+}
+
+_ramble_workspace_manage_filter_groups() {
+    if $list_options
+    then
+        RAMBLE_COMPREPLY="-h --help"
+    else
+        RAMBLE_COMPREPLY="add remove list blame"
+    fi
+}
+
+_ramble_workspace_manage_filter_groups_add() {
+    RAMBLE_COMPREPLY="-h --help -n --name -w --where -ew --exclude-where"
+}
+
+_ramble_workspace_manage_filter_groups_remove() {
+    RAMBLE_COMPREPLY="-h --help -n --name"
+}
+
+_ramble_workspace_manage_filter_groups_list() {
+    RAMBLE_COMPREPLY="-h --help"
+}
+
+_ramble_workspace_manage_filter_groups_blame() {
+    RAMBLE_COMPREPLY="-h --help"
 }

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -297,7 +297,7 @@ _ramble_commands() {
 _ramble_config() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --scope"
+        RAMBLE_COMPREPLY="-h --help -s --scope"
     else
         RAMBLE_COMPREPLY="get blame edit list add remove update revert"
     fi
@@ -406,7 +406,7 @@ _ramble_deployment() {
 }
 
 _ramble_deployment_push() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --deployment-name -d --upload-url -u --phases --include-phase-dependencies --where --exclude-where --filter-tags -fg --filter-group -efg --exclude-filter-group"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --deployment-name -d --upload-url -u --phases --include-phase-dependencies --where --exclude-where --filter-tags --fg --filter-group --efg --exclude-filter-group"
 }
 
 _ramble_deployment_pull() {
@@ -444,7 +444,7 @@ _ramble_filter_groups_remove() {
 }
 
 _ramble_filter_groups_list() {
-    RAMBLE_COMPREPLY="-h --help"
+    RAMBLE_COMPREPLY="-h --help -v --verbose"
 }
 
 _ramble_filter_groups_blame() {
@@ -544,7 +544,7 @@ _ramble_mirror_list() {
 }
 
 _ramble_on() {
-    RAMBLE_COMPREPLY="-h --help --executor --enable-per-experiment-prints --suppress-run-header --where --exclude-where --filter-tags -fg --filter-group -efg --exclude-filter-group"
+    RAMBLE_COMPREPLY="-h --help --executor --enable-per-experiment-prints --suppress-run-header --where --exclude-where --filter-tags --fg --filter-group --efg --exclude-filter-group"
 }
 
 _ramble_python() {
@@ -656,7 +656,7 @@ _ramble_workspace() {
 _ramble_workspace_activate() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat -p --prompt --temp -d --dir --parent-dir --dry-run -fg --filter-group"
+        RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat -p --prompt --temp -d --dir --parent-dir --fg --filter-group --dry-run"
     else
         _workspaces
     fi
@@ -688,11 +688,11 @@ _ramble_workspace_config() {
 }
 
 _ramble_workspace_setup() {
-    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output -fg --filter-group -efg --exclude-filter-group"
+    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output --fg --filter-group --efg --exclude-filter-group"
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output --dry-run -fg --filter-group -efg --exclude-filter-group"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output --fg --filter-group --efg --exclude-filter-group --dry-run"
 }
 
 _ramble_workspace_push_to_cache() {
@@ -700,7 +700,7 @@ _ramble_workspace_push_to_cache() {
 }
 
 _ramble_workspace_info() {
-    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --executables --where --exclude-where --filter-tags -v --verbose --dry-run"
+    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --executables --where --exclude-where --filter-tags --fg --filter-group --efg --exclude-filter-group -v --verbose --dry-run"
 }
 
 _ramble_workspace_edit() {
@@ -775,7 +775,7 @@ _ramble_workspace_manage_modifiers() {
 _ramble_workspace_manage_filter_groups() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help"
+        RAMBLE_COMPREPLY="-h --help --scope"
     else
         RAMBLE_COMPREPLY="add remove list blame"
     fi
@@ -790,7 +790,7 @@ _ramble_workspace_manage_filter_groups_remove() {
 }
 
 _ramble_workspace_manage_filter_groups_list() {
-    RAMBLE_COMPREPLY="-h --help"
+    RAMBLE_COMPREPLY="-h --help -v --verbose"
 }
 
 _ramble_workspace_manage_filter_groups_blame() {


### PR DESCRIPTION
This feature allows users to define named groups of filters (where and exclude_where) globally (in ~/.ramble/filter_groups.yaml) or per-workspace (in workspace ramble.yaml). These groups can be applied to commands using -fg/--filter-group and -efg/--exclude-filter-group with support for logical expressions (e.g., 'G1 and not G2'). Filter groups can also be persistently activated during workspace activation.

TAG=agy
CONV=9ca1006f-e4ba-44fd-80f3-89f837545cc7