### PR TITLE
Add Slurm license support in workflow manager

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -314,3 +314,82 @@ ramble:
             filename,
         )
         assert os.path.isfile(archived_path)
+
+
+def test_slurm_workflow_licenses(
+    mutable_mock_apps_repo, make_workspace_from_config
+):
+    test_config = """
+ramble:
+  variants:
+    workflow_manager: slurm
+  variables:
+    processes_per_node: 5
+    n_nodes: 2
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_no_lic_file: {}
+            test_with_lic_file: {}
+            test_lic_override:
+              variables:
+                slurm_licenses: 'custom_lic:99'
+            test_lic_disable:
+              variables:
+                slurm_licenses: ''
+"""
+
+    ws, _ = make_workspace_from_config(test_config)
+    workspace("setup", "--dry-run", global_args=["-D", ws.root])
+
+    path_no_lic = os.path.join(
+        ws.experiment_dir, "basic", "test_wl", "test_no_lic_file"
+    )
+    with open(
+        os.path.join(path_no_lic, "slurm_experiment_sbatch"), encoding="utf-8"
+    ) as f:
+        content = f.read()
+        assert "--licenses" not in content
+
+    test_licenses = """
+licenses:
+  basic:
+    set:
+      TEST_VAR: test_val
+"""
+    license_path = os.path.join(ws.config_dir, "licenses.yaml")
+    with open(license_path, "w+", encoding="utf-8") as f:
+        f.write(test_licenses)
+
+    workspace("setup", "--dry-run", global_args=["-D", ws.root])
+
+    path_with_lic = os.path.join(
+        ws.experiment_dir, "basic", "test_wl", "test_with_lic_file"
+    )
+    with open(
+        os.path.join(path_with_lic, "slurm_experiment_sbatch"),
+        encoding="utf-8",
+    ) as f:
+        content = f.read()
+        assert "#SBATCH --licenses=basic:10" in content
+
+    path_override = os.path.join(
+        ws.experiment_dir, "basic", "test_wl", "test_lic_override"
+    )
+    with open(
+        os.path.join(path_override, "slurm_experiment_sbatch"),
+        encoding="utf-8",
+    ) as f:
+        content = f.read()
+        assert "#SBATCH --licenses=custom_lic:99" in content
+
+    path_disable = os.path.join(
+        ws.experiment_dir, "basic", "test_wl", "test_lic_disable"
+    )
+    with open(
+        os.path.join(path_disable, "slurm_experiment_sbatch"), encoding="utf-8"
+    ) as f:
+        content = f.read()
+        assert "--licenses" not in content

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -9,6 +9,7 @@
 import datetime
 import os
 
+from ramble import config
 from ramble.experiment_result import ExperimentStatus
 from ramble.util import shell_utils
 from ramble.wmkit import *
@@ -96,6 +97,12 @@ class Slurm(WorkflowManagerBase):
         name="slurm_partition",
         default="",
         description="partition to submit job to, if unspecified, it uses the default partition",
+    )
+
+    workflow_manager_variable(
+        name="slurm_licenses",
+        default=None,
+        description="Slurm licenses required by the job, e.g. fluent:64",
     )
 
     workflow_manager_variable(
@@ -204,6 +211,26 @@ class Slurm(WorkflowManagerBase):
         partition = expander.expand_var_name("slurm_partition")
         if partition:
             pragmas.append("#SBATCH -p {slurm_partition}")
+
+        slurm_licenses = expander.expand_var_name("slurm_licenses", typed=True)
+        if slurm_licenses is None:
+            license_conf = config.get("licenses")
+            if license_conf:
+                matched_license = next(
+                    (
+                        lic
+                        for lic in app_inst.license_names
+                        if lic in license_conf
+                    ),
+                    None,
+                )
+                if matched_license:
+                    n_ranks = expander.expand_var("{n_ranks}")
+                    slurm_licenses = f"{matched_license}:{n_ranks}"
+
+        if slurm_licenses:
+            pragmas.append(f"#SBATCH --licenses={slurm_licenses}")
+
         extra_headers = (
             expander.expand_var_name("extra_sbatch_headers")
             .strip()


### PR DESCRIPTION
The default behavior works by:

1. Check for the presence of matching license in the config
2. If license info is found, assume the app instance requires license, and use the license name to specify `{license_name}:{n_ranks}` for the sbatch license header
3. This can be overridden via the `slurm_licenses` workflow manager variable

This is the "client" side, in practice, this expects the Slurm cluster to configure the license limit properly.