### PR TITLE
make edit type deducible

### DIFF
--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -58,6 +58,97 @@ def edit_object(name, obj_type_name, repo_path, namespace):
         logger.die("No valid editor was found.")
 
 
+def normalize_type_name(type_name):
+    if not type_name:
+        return None
+
+    # Map aliases
+    aliases = {
+        "test": "test",
+        "tests": "test",
+        "command": "command",
+        "commands": "command",
+        "docs": "docs",
+        "doc": "docs",
+        "module": "module",
+        "modules": "module",
+    }
+    if type_name in aliases:
+        return aliases[type_name]
+
+    # Map singular to plural for ObjectTypes
+    norm_type = type_name.lower().replace("-", " ").replace("_", " ")
+    for obj_type in ramble.repository.ObjectTypes:
+        if norm_type == obj_type.name.lower().replace("_", " "):
+            return obj_type.name
+        if obj_type in ramble.repository.type_definitions:
+            singular = ramble.repository.type_definitions[obj_type]["singular"]
+            if norm_type == singular.lower().replace("_", " ").replace("-", " "):
+                return obj_type.name
+
+    return type_name
+
+
+def object_exists(name, obj_type_name, repo_path=None, namespace=None):
+    try:
+        obj_type = ramble.repository.ObjectTypes[obj_type_name]
+        if repo_path:
+            repo = ramble.repository.Repo(repo_path, object_type=obj_type)
+        elif namespace:
+            repo = ramble.repository.paths[obj_type].get_repo(namespace)
+        else:
+            repo = ramble.repository.paths[obj_type]
+        # Check if the filename for the object name exists
+        path = repo.filename_for_object_name(name)
+        return os.path.exists(path)
+    except Exception:
+        return False
+
+
+def non_object_exists(name, type_name):
+    type_to_path = {
+        "test": ramble.paths.test_path,
+        "command": ramble.paths.command_path,
+        "docs": os.path.join(ramble.paths.lib_path, "docs"),
+        "module": ramble.paths.module_path,
+    }
+    path = type_to_path[type_name]
+    # convert command names to python module name
+    if path == ramble.paths.command_path:
+        name = ramble.cmd.python_name(name)
+
+    path = os.path.join(path, name)
+    if os.path.exists(path):
+        return True
+
+    # Otherwise do a glob check (excluding backups/pyc)
+    files = glob.glob(path + ".*")
+    exclude_list = [".pyc", "~"]
+    files = list(filter(lambda x: all(s not in x for s in exclude_list), files))
+    return len(files) > 0
+
+
+def deduce_type(name, repo_path=None, namespace=None):
+    # Try default type first (applications)
+    default_type = ramble.repository.default_type.name
+    if object_exists(name, default_type, repo_path, namespace):
+        return default_type
+
+    # Search all other object types
+    for obj_type_name in ramble.repository.OBJECT_NAMES:
+        if obj_type_name == default_type:
+            continue
+        if object_exists(name, obj_type_name, repo_path, namespace):
+            return obj_type_name
+
+    # Search non-object types
+    for type_name in ["test", "command", "module", "docs"]:
+        if non_object_exists(name, type_name):
+            return type_name
+
+    return None
+
+
 def setup_parser(subparser):
     # Edits object (application) files by default
     extra_types = ["test", "command", "docs", "module"]
@@ -65,8 +156,9 @@ def setup_parser(subparser):
     subparser.add_argument(
         "-t",
         "--type",
-        default=f"{ramble.repository.default_type.name}",
-        help=f"Type of object to edit. Defaults to '{ramble.repository.default_type.name}'. "
+        default=None,
+        help="Type of object to edit. Defaults to automatic deduction with fallback to "
+        f"'{ramble.repository.default_type.name}'. "
         f"Allowed types are {', '.join(allowed_types)}",
     )
 
@@ -85,16 +177,25 @@ def edit(parser, args):
     # By default, edit object files
     path = ramble.paths.builtin_path
 
+    # Normalize input type if specified
+    if args.type:
+        args.type = normalize_type_name(args.type)
+
+    if name and not args.type:
+        detected_type = deduce_type(name, args.repo, args.namespace)
+        if detected_type:
+            args.type = detected_type
+
+    # Default type if still not set
+    if not args.type:
+        args.type = ramble.repository.default_type.name
+
     # Map type arguments to paths if they aren't standard object types
     type_to_path = {
         "test": ramble.paths.test_path,
-        "tests": ramble.paths.test_path,
         "command": ramble.paths.command_path,
-        "commands": ramble.paths.command_path,
         "docs": os.path.join(ramble.paths.lib_path, "docs"),
-        "doc": os.path.join(ramble.paths.lib_path, "docs"),
         "module": ramble.paths.module_path,
-        "modules": ramble.paths.module_path,
     }
 
     if args.type in type_to_path:
@@ -106,7 +207,7 @@ def edit(parser, args):
 
             path = os.path.join(path, name)
             if not os.path.exists(path):
-                files = glob.glob(path + "*")
+                files = glob.glob(path + ".*")
                 exclude_list = [".pyc", "~"]  # exclude binaries and backups
                 files = list(filter(lambda x: all(s not in x for s in exclude_list), files))
                 if len(files) > 1:

--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -60,48 +60,17 @@ def edit_object(name, obj_type_name, repo_path, namespace):
 
 def setup_parser(subparser):
     # Edits object (application) files by default
+    extra_types = ["test", "command", "docs", "module"]
+    allowed_types = ramble.repository.OBJECT_NAMES + extra_types
     subparser.add_argument(
+        "-t",
         "--type",
         default=f"{ramble.repository.default_type.name}",
         help=f"Type of object to edit. Defaults to '{ramble.repository.default_type.name}'. "
-        f"Allowed types are {', '.join(ramble.repository.OBJECT_NAMES)}",
+        f"Allowed types are {', '.join(allowed_types)}",
     )
 
     excl_args = subparser.add_mutually_exclusive_group()
-
-    # Various types of Ramble files that can be edited
-    excl_args.add_argument(
-        "-c",
-        "--command",
-        dest="path",
-        action="store_const",
-        const=ramble.paths.command_path,
-        help="edit the command with the supplied name",
-    )
-    excl_args.add_argument(
-        "-d",
-        "--docs",
-        dest="path",
-        action="store_const",
-        const=os.path.join(ramble.paths.lib_path, "docs"),
-        help="edit the docs with the supplied name",
-    )
-    excl_args.add_argument(
-        "-t",
-        "--test",
-        dest="path",
-        action="store_const",
-        const=ramble.paths.test_path,
-        help="edit the test with the supplied name",
-    )
-    excl_args.add_argument(
-        "-m",
-        "--module",
-        dest="path",
-        action="store_const",
-        const=ramble.paths.module_path,
-        help="edit the main ramble module with the supplied name",
-    )
 
     # Options for editing applications
     excl_args.add_argument("-r", "--repo", default=None, help="path to repo to edit object in")
@@ -116,9 +85,20 @@ def edit(parser, args):
     # By default, edit object files
     path = ramble.paths.builtin_path
 
-    # If `--command`, `--test`, or `--module` is chosen, edit those instead
-    if args.path:
-        path = args.path
+    # Map type arguments to paths if they aren't standard object types
+    type_to_path = {
+        "test": ramble.paths.test_path,
+        "tests": ramble.paths.test_path,
+        "command": ramble.paths.command_path,
+        "commands": ramble.paths.command_path,
+        "docs": os.path.join(ramble.paths.lib_path, "docs"),
+        "doc": os.path.join(ramble.paths.lib_path, "docs"),
+        "module": ramble.paths.module_path,
+        "modules": ramble.paths.module_path,
+    }
+
+    if args.type in type_to_path:
+        path = type_to_path[args.type]
         if name:
             # convert command names to python module name
             if path == ramble.paths.command_path:

--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -21,43 +21,6 @@ section = "application dev"
 level = "short"
 
 
-def edit_object(name, obj_type_name, repo_path, namespace):
-    """Opens the requested application file in your favorite $EDITOR.
-
-    Args:
-        name (str): The name of the application
-        obj_type_name (str): Name of the object type to edit
-        repo_path (str): The path to the repository containing this application
-        namespace (str): A valid namespace registered with Ramble
-    """
-    obj_type = ramble.repository.ObjectTypes[obj_type_name]
-    # Find the location of the package
-    if repo_path:
-        repo = ramble.repository.Repo(repo_path, object_type=obj_type)
-    elif namespace:
-        repo = ramble.repository.paths[obj_type].get_repo(namespace)
-    else:
-        repo = ramble.repository.paths[obj_type]
-    path = repo.filename_for_object_name(name)
-
-    if os.path.exists(path):
-        if not os.path.isfile(path):
-            logger.die(f"Something is wrong. '{path}' is not a file!")
-        if not os.access(path, os.R_OK):
-            logger.die(f"Insufficient permissions on '{path}'!")
-    else:
-        # TODO: Update this once a `ramble create` command exists
-        logger.die(
-            f"No application for '{name}' was found."
-            # "  Use `ramble create` to create a new application"
-        )
-
-    try:
-        editor(path)
-    except TypeError:
-        logger.die("No valid editor was found.")
-
-
 def normalize_type_name(type_name):
     if not type_name:
         return None
@@ -89,64 +52,75 @@ def normalize_type_name(type_name):
     return type_name
 
 
-def object_exists(name, obj_type_name, repo_path=None, namespace=None):
-    try:
-        obj_type = ramble.repository.ObjectTypes[obj_type_name]
-        if repo_path:
-            repo = ramble.repository.Repo(repo_path, object_type=obj_type)
-        elif namespace:
-            repo = ramble.repository.paths[obj_type].get_repo(namespace)
-        else:
-            repo = ramble.repository.paths[obj_type]
-        # Check if the filename for the object name exists
-        path = repo.filename_for_object_name(name)
-        return os.path.exists(path)
-    except Exception:
-        return False
+def find_all_matches(name, repo_path=None, namespace=None, obj_type=None):
+    """Find all potential file paths that match the given name.
 
+    Returns a list of dictionaries with keys:
+    - 'type': type of object/file
+    - 'path': path of the file
+    - 'repo_namespace': namespace of the repository (if applicable, else None)
+    """
+    matches = []
 
-def non_object_exists(name, type_name):
-    type_to_path = {
-        "test": ramble.paths.test_path,
-        "command": ramble.paths.command_path,
-        "docs": os.path.join(ramble.paths.lib_path, "docs"),
-        "module": ramble.paths.module_path,
-    }
-    path = type_to_path[type_name]
-    # convert command names to python module name
-    if path == ramble.paths.command_path:
-        name = ramble.cmd.python_name(name)
+    extra_types = ["test", "command", "docs", "module"]
+    allowed_types = ramble.repository.OBJECT_NAMES + extra_types
 
-    path = os.path.join(path, name)
-    if os.path.exists(path):
-        return True
+    types_to_check = [obj_type] if obj_type else allowed_types
 
-    # Otherwise do a glob check (excluding backups/pyc)
-    files = glob.glob(path + ".*")
-    exclude_list = [".pyc", "~"]
-    files = list(filter(lambda x: all(s not in x for s in exclude_list), files))
-    return len(files) > 0
+    for t in types_to_check:
+        if t in ramble.repository.OBJECT_NAMES:
+            # Check object type
+            obj_type = ramble.repository.ObjectTypes[t]
+            if repo_path:
+                try:
+                    repos = [ramble.repository.Repo(repo_path, object_type=obj_type)]
+                except Exception:
+                    repos = []
+            elif namespace:
+                try:
+                    repos = [ramble.repository.paths[obj_type].get_repo(namespace)]
+                except Exception:
+                    repos = []
+            else:
+                repos = ramble.repository.paths[obj_type].repos
 
+            for repo in repos:
+                path = repo.filename_for_object_name(name)
+                if os.path.isfile(path):
+                    matches.append({"type": t, "path": path, "repo_namespace": repo.namespace})
+        elif t in extra_types:
+            # Check non-object type
+            if repo_path or namespace:
+                continue
 
-def deduce_type(name, repo_path=None, namespace=None):
-    # Try default type first (applications)
-    default_type = ramble.repository.default_type.name
-    if object_exists(name, default_type, repo_path, namespace):
-        return default_type
+            type_to_path = {
+                "test": ramble.paths.test_path,
+                "command": ramble.paths.command_path,
+                "docs": os.path.join(ramble.paths.lib_path, "docs"),
+                "module": ramble.paths.module_path,
+            }
+            path = type_to_path[t]
+            if t == "command":
+                name_file = ramble.cmd.python_name(name)
+            else:
+                name_file = name
 
-    # Search all other object types
-    for obj_type_name in ramble.repository.OBJECT_NAMES:
-        if obj_type_name == default_type:
-            continue
-        if object_exists(name, obj_type_name, repo_path, namespace):
-            return obj_type_name
+            full_path = os.path.join(path, name_file)
+            if os.path.isfile(full_path):
+                matches.append({"type": t, "path": full_path, "repo_namespace": None})
+            else:
+                # Do a glob check (excluding backups/pyc)
+                files = glob.glob(full_path + ".*")
+                exclude_list = [".pyc", "~"]
+                files = list(
+                    filter(
+                        lambda x: os.path.isfile(x) and all(s not in x for s in exclude_list),
+                        files,
+                    )
+                )
+                matches.extend({"type": t, "path": f, "repo_namespace": None} for f in files)
 
-    # Search non-object types
-    for type_name in ["test", "command", "module", "docs"]:
-        if non_object_exists(name, type_name):
-            return type_name
-
-    return None
+    return matches
 
 
 def setup_parser(subparser):
@@ -174,60 +148,128 @@ def setup_parser(subparser):
 def edit(parser, args):
     name = args.object_name
 
-    # By default, edit object files
-    path = ramble.paths.builtin_path
-
     # Normalize input type if specified
     if args.type:
         args.type = normalize_type_name(args.type)
+        extra_types = ["test", "command", "docs", "module"]
+        allowed_types = ramble.repository.OBJECT_NAMES + extra_types
+        if args.type not in allowed_types:
+            # Trigger KeyError like the original code did
+            _ = ramble.repository.ObjectTypes[args.type]
 
-    if name and not args.type:
-        detected_type = deduce_type(name, args.repo, args.namespace)
-        if detected_type:
-            args.type = detected_type
+    if name:
+        matches = find_all_matches(name, args.repo, args.namespace, args.type)
 
-    # Default type if still not set
-    if not args.type:
-        args.type = ramble.repository.default_type.name
-
-    # Map type arguments to paths if they aren't standard object types
-    type_to_path = {
-        "test": ramble.paths.test_path,
-        "command": ramble.paths.command_path,
-        "docs": os.path.join(ramble.paths.lib_path, "docs"),
-        "module": ramble.paths.module_path,
-    }
-
-    if args.type in type_to_path:
-        path = type_to_path[args.type]
-        if name:
-            # convert command names to python module name
-            if path == ramble.paths.command_path:
-                name = ramble.cmd.python_name(name)
-
-            path = os.path.join(path, name)
-            if not os.path.exists(path):
-                files = glob.glob(path + ".*")
-                exclude_list = [".pyc", "~"]  # exclude binaries and backups
-                files = list(filter(lambda x: all(s not in x for s in exclude_list), files))
-                if len(files) > 1:
+        if len(matches) >= 1:
+            if len(matches) > 1:
+                # Check if all matches are of the same non-object type (glob search matches)
+                # which means they are just different suffixes for the same name/type
+                first_match_type = matches[0]["type"]
+                extra_types = ["test", "command", "docs", "module"]
+                if first_match_type in extra_types and all(
+                    m["type"] == first_match_type for m in matches
+                ):
                     m = f"Multiple files exist with the name {name}."
                     m += " Please specify a suffix. Files are:\n\n"
-                    for f in files:
-                        m += "        " + os.path.basename(f) + "\n"
+                    for match in matches:
+                        m += "        " + os.path.basename(match["path"]) + "\n"
                     logger.die(m)
-                if not files:
-                    logger.die(f"No file for '{name}' was found in {path}")
-                path = files[0]  # already confirmed only one entry in files
 
-        try:
-            editor(path)
-        except TypeError:
-            logger.die("No valid editor was found.")
-    elif name:
-        edit_object(name, args.type, args.repo, args.namespace)
+                m = (
+                    f"Multiple matches found for '{name}'. "
+                    f"Opening highest-precedence match:\n  {matches[0]['path']}\n"
+                )
+                m += "In order to open a different object, use the commands below:\n"
+                for match in matches[1:]:
+                    if match["repo_namespace"]:
+                        m += (
+                            f"  Type: {match['type']}, "
+                            f"Command: ramble edit --type {match['type']} "
+                            f"--namespace {match['repo_namespace']} {name}\n"
+                        )
+                    else:
+                        m += (
+                            f"  Type: {match['type']}, "
+                            f"Command: ramble edit --type {match['type']} {name}\n"
+                        )
+                logger.warn(m)
+
+            path = matches[0]["path"]
+            if not os.access(path, os.R_OK):
+                logger.die(f"Insufficient permissions on '{path}'!")
+
+            try:
+                editor(path)
+            except TypeError:
+                logger.die("No valid editor was found.")
+            return
+
+        # If no matches found, reproduce the original behavior/messages:
+        # 1. If type is specified/defaulted, we show type-specific "not found" messages.
+        type_name = args.type or ramble.repository.default_type.name
+        type_to_path = {
+            "test": ramble.paths.test_path,
+            "command": ramble.paths.command_path,
+            "docs": os.path.join(ramble.paths.lib_path, "docs"),
+            "module": ramble.paths.module_path,
+        }
+
+        if type_name in type_to_path:
+            path = type_to_path[type_name]
+            if type_name == "command":
+                name = ramble.cmd.python_name(name)
+            path = os.path.join(path, name)
+            logger.die(f"No file for '{name}' was found in {path}")
+        else:
+            # It's an object type. Let's find what path it would have been at.
+            try:
+                obj_type = ramble.repository.ObjectTypes[type_name]
+                if args.repo:
+                    repo = ramble.repository.Repo(args.repo, object_type=obj_type)
+                elif args.namespace:
+                    repo = ramble.repository.paths[obj_type].get_repo(args.namespace)
+                else:
+                    repo = ramble.repository.paths[obj_type]
+                path = repo.filename_for_object_name(name)
+            except Exception:
+                path = None
+
+            if path and os.path.exists(path):
+                if not os.path.isfile(path):
+                    logger.die(f"Something is wrong. '{path}' is not a file!")
+
+            # Print standard error message
+            if type_name == ramble.repository.default_type.name:
+                logger.die(f"No application for '{name}' was found.")
+            else:
+                # For other object types, print a generic not found message
+                logger.die(f"No {type_name} for '{name}' was found.")
     else:
-        # By default open the directory where applications live
+        # By default, open the directory where applications live
+        path = ramble.paths.builtin_path
+        if args.type:
+            type_to_path = {
+                "test": ramble.paths.test_path,
+                "command": ramble.paths.command_path,
+                "docs": os.path.join(ramble.paths.lib_path, "docs"),
+                "module": ramble.paths.module_path,
+            }
+            if args.type in type_to_path:
+                path = type_to_path[args.type]
+            else:
+                try:
+                    obj_type = ramble.repository.ObjectTypes[args.type]
+                    if args.repo:
+                        repo = ramble.repository.Repo(args.repo, object_type=obj_type)
+                    elif args.namespace:
+                        repo = ramble.repository.paths[obj_type].get_repo(args.namespace)
+                    else:
+                        repo = ramble.repository.paths[obj_type]
+                    # Default path to the repo root/objects folder
+                    path = repo.objects_path
+                except Exception:
+                    pass
+
         try:
             editor(path)
         except TypeError:

--- a/lib/ramble/ramble/test/cmd/edit.py
+++ b/lib/ramble/ramble/test/cmd/edit.py
@@ -34,35 +34,35 @@ def mock_editor(monkeypatch):
 
 
 def test_edit_command(mock_editor):
-    """Test `ramble edit --command <cmd>`"""
-    edit("--command", "edit")
+    """Test `ramble edit -t command <cmd>`"""
+    edit("-t", "command", "edit")
     assert len(mock_editor) == 1
     assert "ramble/cmd/edit.py" in mock_editor[0]
 
 
 def test_edit_test(mock_editor):
-    """Test `ramble edit --test <test>`"""
-    edit("--test", "cmd/edit")
+    """Test `ramble edit -t test <test>`"""
+    edit("-t", "test", "cmd/edit")
     assert len(mock_editor) == 1
     assert "ramble/test/cmd/edit.py" in mock_editor[0]
 
 
 def test_edit_module(mock_editor):
-    """Test `ramble edit --module <module>`"""
-    edit("--module", "config")
+    """Test `ramble edit -t module <module>`"""
+    edit("-t", "module", "config")
     assert len(mock_editor) == 1
     assert "ramble/config.py" in mock_editor[0]
 
 
 def test_edit_docs(mock_editor):
-    """Test `ramble edit --docs <doc>`"""
-    edit("--docs", "index.rst")
+    """Test `ramble edit -t docs <doc>`"""
+    edit("-t", "docs", "index.rst")
     assert len(mock_editor) == 1
     assert "docs/index.rst" in mock_editor[0]
 
 
 def test_edit_file_not_found():
-    output = edit("--command", "non-existent-cmd", fail_on_error=False)
+    output = edit("-t", "command", "non-existent-cmd", fail_on_error=False)
     assert "No file for 'non_existent_cmd' was found" in output
 
 
@@ -73,6 +73,6 @@ def test_edit_application(mock_applications, mock_editor):
 
 
 def test_edit_modifier(mock_modifiers, mock_editor):
-    edit("info", "--type", "modifiers")
+    edit("info", "-t", "modifiers")
     assert len(mock_editor) == 1
     assert "repos/builtin.mock/modifiers/info/modifier.py" in mock_editor[0]

--- a/lib/ramble/ramble/test/cmd/edit.py
+++ b/lib/ramble/ramble/test/cmd/edit.py
@@ -76,3 +76,122 @@ def test_edit_modifier(mock_modifiers, mock_editor):
     edit("info", "-t", "modifiers")
     assert len(mock_editor) == 1
     assert "repos/builtin.mock/modifiers/info/modifier.py" in mock_editor[0]
+
+
+def test_edit_deduction_modifier(mock_modifiers, mock_editor):
+    """Test `ramble edit info` deduces it's a modifier"""
+    edit("info")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/modifiers/info/modifier.py" in mock_editor[0]
+
+
+def test_edit_singular_type(mock_modifiers, mock_editor):
+    """Test `ramble edit -t modifier info` normalizes singular type"""
+    edit("info", "-t", "modifier")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/modifiers/info/modifier.py" in mock_editor[0]
+
+
+def test_edit_deduction_command(mock_editor):
+    """Test `ramble edit edit` deduces it's a command"""
+    edit("edit")
+    assert len(mock_editor) == 1
+    assert "ramble/cmd/edit.py" in mock_editor[0]
+
+
+def test_edit_deduction_test(mock_editor):
+    """Test `ramble edit cmd/edit` deduces it's a test"""
+    edit("cmd/edit")
+    assert len(mock_editor) == 1
+    assert "ramble/test/cmd/edit.py" in mock_editor[0]
+
+
+def test_edit_singular_type_with_spaces_hyphens(mock_editor):
+    """Test package manager singular forms normalization with spaces/hyphens"""
+    edit("spack", "-t", "package-manager")
+    assert len(mock_editor) == 1
+    assert "package_managers/spack/package_manager.py" in mock_editor[0]
+
+    edit("spack", "-t", "package_manager")
+    assert len(mock_editor) == 2
+    assert "package_managers/spack/package_manager.py" in mock_editor[1]
+
+
+def test_edit_unknown_type():
+    with pytest.raises(KeyError):
+        edit("-t", "unknown_type", "spack")
+
+
+def test_edit_with_repo(mock_applications, mock_editor):
+    import ramble.repository
+
+    repo_path = ramble.repository.paths[ramble.repository.ObjectTypes.applications].repos[0].root
+    edit("basic", "--repo", repo_path)
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/applications/basic/application.py" in mock_editor[0]
+
+
+def test_edit_with_namespace(mock_applications, mock_editor):
+    edit("basic", "--namespace", "builtin.mock")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/applications/basic/application.py" in mock_editor[0]
+
+
+def test_edit_deduction_docs(mock_editor):
+    edit("index.rst")
+    assert len(mock_editor) == 1
+    assert "docs/index.rst" in mock_editor[0]
+
+
+def test_edit_deduction_fails_correctly():
+    output = edit("non-existent-object-name", fail_on_error=False)
+    assert "No application for 'non-existent-object-name' was found" in output
+
+
+def test_object_exists_exception():
+    from ramble.cmd.edit import object_exists
+
+    assert not object_exists("some_name", "invalid_type_name")
+
+
+def test_normalize_type_name_empty():
+    from ramble.cmd.edit import normalize_type_name
+
+    assert normalize_type_name(None) is None
+    assert normalize_type_name("") is None
+
+
+def test_edit_object_is_directory(mock_applications, monkeypatch):
+
+    import ramble.repository
+
+    monkeypatch.setattr(
+        ramble.repository.Repo, "filename_for_object_name", lambda self, name: self.root
+    )
+    output = edit("basic", fail_on_error=False)
+    assert "is not a file!" in output
+
+
+def test_edit_object_insufficient_permissions(mock_applications, monkeypatch):
+    import os
+
+    monkeypatch.setattr(os, "access", lambda path, mode: False)
+    output = edit("basic", fail_on_error=False)
+    assert "Insufficient permissions" in output
+
+
+def test_edit_no_editor_found(mock_applications, monkeypatch):
+    def mock_fail_editor(*args, **kwargs):
+        raise TypeError("No editor")
+
+    monkeypatch.setattr("ramble.cmd.edit.editor", mock_fail_editor)
+    output = edit("basic", fail_on_error=False)
+    assert "No valid editor was found" in output
+
+
+def test_edit_multiple_files_found(monkeypatch):
+    import glob
+
+    monkeypatch.setattr(glob, "glob", lambda pattern: ["file1.py", "file2.py"])
+    output = edit("-t", "command", "non-existent", fail_on_error=False)
+    assert "Multiple files exist" in output

--- a/lib/ramble/ramble/test/cmd/edit.py
+++ b/lib/ramble/ramble/test/cmd/edit.py
@@ -79,10 +79,10 @@ def test_edit_modifier(mock_modifiers, mock_editor):
 
 
 def test_edit_deduction_modifier(mock_modifiers, mock_editor):
-    """Test `ramble edit info` deduces it's a modifier"""
-    edit("info")
+    """Test `ramble edit versions-mod` deduces it's a modifier"""
+    edit("versions-mod")
     assert len(mock_editor) == 1
-    assert "repos/builtin.mock/modifiers/info/modifier.py" in mock_editor[0]
+    assert "repos/builtin.mock/modifiers/versions-mod/modifier.py" in mock_editor[0]
 
 
 def test_edit_singular_type(mock_modifiers, mock_editor):
@@ -100,10 +100,10 @@ def test_edit_deduction_command(mock_editor):
 
 
 def test_edit_deduction_test(mock_editor):
-    """Test `ramble edit cmd/edit` deduces it's a test"""
-    edit("cmd/edit")
+    """Test `ramble edit application` deduces it's a test"""
+    edit("application")
     assert len(mock_editor) == 1
-    assert "ramble/test/cmd/edit.py" in mock_editor[0]
+    assert "ramble/test/application.py" in mock_editor[0]
 
 
 def test_edit_singular_type_with_spaces_hyphens(mock_editor):
@@ -148,12 +148,6 @@ def test_edit_deduction_fails_correctly():
     assert "No application for 'non-existent-object-name' was found" in output
 
 
-def test_object_exists_exception():
-    from ramble.cmd.edit import object_exists
-
-    assert not object_exists("some_name", "invalid_type_name")
-
-
 def test_normalize_type_name_empty():
     from ramble.cmd.edit import normalize_type_name
 
@@ -191,7 +185,72 @@ def test_edit_no_editor_found(mock_applications, monkeypatch):
 
 def test_edit_multiple_files_found(monkeypatch):
     import glob
+    import os
 
     monkeypatch.setattr(glob, "glob", lambda pattern: ["file1.py", "file2.py"])
+    monkeypatch.setattr(os.path, "isfile", lambda path: path in ["file1.py", "file2.py"])
     output = edit("-t", "command", "non-existent", fail_on_error=False)
     assert "Multiple files exist" in output
+
+
+def test_edit_multiple_matches_warning(mock_applications, mock_modifiers, mock_editor):
+    output = edit("info", fail_on_error=False)
+    assert "Multiple matches found for 'info'" in output
+    assert "Opening highest-precedence match:" in output
+    assert "In order to open a different object, use the commands below:" in output
+    assert (
+        "Type: modifiers, Command: ramble edit --type modifiers --namespace builtin.mock info"
+        in output
+    )
+    assert "Type: command, Command: ramble edit --type command info" in output
+
+
+def test_edit_object_fallback_repo():
+    output = edit("non-existent", "--repo", "/non-existent-path", fail_on_error=False)
+    assert "No application for 'non-existent' was found" in output
+
+
+def test_edit_object_fallback_namespace():
+    output = edit("non-existent", "--namespace", "non-existent-namespace", fail_on_error=False)
+    assert "No application for 'non-existent' was found" in output
+
+
+def test_edit_object_fallback_custom_type_not_found(mock_modifiers):
+    output = edit("non-existent-modifier", "-t", "modifiers", fail_on_error=False)
+    assert "No modifiers for 'non-existent-modifier' was found" in output
+
+
+def test_edit_no_name_default_editor(mock_editor):
+    edit()
+    assert len(mock_editor) == 1
+    assert "var/ramble/repos/builtin" in mock_editor[0]
+
+
+def test_edit_no_name_with_type_editor(mock_editor):
+    edit("-t", "command")
+    assert len(mock_editor) == 1
+    assert "lib/ramble/ramble/cmd" in mock_editor[0]
+
+    edit("-t", "applications")
+    assert len(mock_editor) == 2
+    assert "var/ramble/repos/builtin" in mock_editor[1]
+
+
+def test_edit_no_name_with_custom_type_repo_editor(mock_editor):
+    edit("-t", "applications", "--repo", "/non-existent-path")
+    assert len(mock_editor) == 1
+
+
+def test_edit_no_name_with_custom_type_namespace_editor(mock_applications, mock_editor):
+    edit("-t", "applications", "--namespace", "builtin.mock")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/applications" in mock_editor[0]
+
+
+def test_edit_no_name_no_editor(monkeypatch):
+    def mock_fail_editor(*args, **kwargs):
+        raise TypeError("No editor")
+
+    monkeypatch.setattr("ramble.cmd.edit.editor", mock_fail_editor)
+    output = edit(fail_on_error=False)
+    assert "No valid editor was found" in output

--- a/lib/ramble/ramble/test/edit_file_validation.py
+++ b/lib/ramble/ramble/test/edit_file_validation.py
@@ -215,3 +215,298 @@ def test_edit_file_directive_empty_app():
     edit_func = edit_file("my_edit", "/path/f", match="a", replace="b")
     edit_func(app)
     assert "my_edit" in app.executables[frozenset()]
+
+
+@pytest.fixture
+def editor_script_path(tmpdir):
+    from ramble.util.file_editor import get_file_editor_script
+
+    script_path = tmpdir.join("test_file_editor.py")
+    script_path.write(get_file_editor_script())
+    return str(script_path)
+
+
+@pytest.fixture
+def run_editor(editor_script_path):
+    import subprocess
+    import sys
+
+    def _run(*args):
+        return subprocess.run(
+            [sys.executable, editor_script_path] + list(args),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+
+    return _run
+
+
+def test_editor_script_regex_basic(tmpdir, run_editor):
+    # Create a test file
+    test_file = tmpdir.join("test.txt")
+    test_file.write("hello world\nthis is a test\n")
+
+    # Run the editor script to replace "world" with "ramble"
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--match",
+        "world",
+        "--replace",
+        "ramble",
+    )
+
+    assert res.returncode == 0
+    assert test_file.read() == "hello ramble\nthis is a test\n"
+
+
+def test_editor_script_regex_append_prepend(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("content\n")
+
+    # Run editor script with append and prepend
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--append",
+        "\\nfooter\\n",
+        "--prepend",
+        "header\\n\\n",
+    )
+
+    assert res.returncode == 0
+    assert test_file.read() == "header\n\ncontent\n\nfooter\n"
+
+
+def test_editor_script_custom_function(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("original content")
+
+    # Create a custom module with an edit function
+    module_file = tmpdir.join("custom_funcs.py")
+    module_file.write(
+        "def my_edit(content):\n" "    return content.replace('original', 'modified')\n"
+    )
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--import-module",
+        str(module_file),
+        "--function",
+        "my_edit",
+    )
+
+    assert res.returncode == 0
+    assert test_file.read() == "modified content"
+
+
+def test_editor_script_custom_function_invalid_return(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("content")
+
+    module_file = tmpdir.join("custom_funcs.py")
+    module_file.write("def invalid_edit(content):\n" "    return 123\n")
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--import-module",
+        str(module_file),
+        "--function",
+        "invalid_edit",
+    )
+
+    assert res.returncode == 1
+    assert "must return a string, not int" in (res.stdout + res.stderr)
+
+
+def test_editor_script_custom_function_not_found(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("content")
+
+    module_file = tmpdir.join("custom_funcs.py")
+    module_file.write("def valid_edit(content):\n" "    return content\n")
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--import-module",
+        str(module_file),
+        "--function",
+        "missing_edit",
+    )
+
+    assert res.returncode == 1
+    assert "Function missing_edit not found" in (res.stdout + res.stderr)
+
+
+def test_editor_script_module_not_found(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("content")
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--import-module",
+        str(tmpdir.join("non_existent_module.py")),
+        "--function",
+        "my_edit",
+    )
+
+    assert res.returncode == 1
+    output = res.stdout + res.stderr
+    assert "Module file" in output
+    assert "not found" in output
+
+
+def test_editor_script_patch_success(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("line 1\nline 2\nline 3\n")
+
+    patch_file = tmpdir.join("test.patch")
+    patch_file.write(
+        "--- test.txt\n"
+        "+++ test.txt\n"
+        "@@ -1,3 +1,3 @@\n"
+        " line 1\n"
+        "-line 2\n"
+        "+line 2 modified\n"
+        " line 3\n"
+    )
+
+    res = run_editor(
+        "--mode",
+        "patch",
+        "--file",
+        str(test_file),
+        "--patch-file",
+        str(patch_file),
+    )
+
+    assert res.returncode == 0
+    assert "line 2 modified" in test_file.read()
+
+
+def test_editor_script_patch_failure(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("line 1\nline 2\nline 3\n")
+
+    # Invalid patch file contents
+    patch_file = tmpdir.join("test.patch")
+    patch_file.write("invalid patch contents\n")
+
+    res = run_editor(
+        "--mode",
+        "patch",
+        "--file",
+        str(test_file),
+        "--patch-file",
+        str(patch_file),
+    )
+
+    assert res.returncode == 1
+    assert "Error applying patch" in (res.stdout + res.stderr)
+
+
+def test_editor_script_preserves_line_endings(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write_binary(b"line1\r\nline2\r\n")
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--match",
+        "line1",
+        "--replace",
+        "modified1",
+    )
+
+    assert res.returncode == 0
+    content = test_file.read_binary()
+    assert b"\r\n" in content
+    assert b"\n" not in content.replace(b"\r\n", b"")
+    assert content == b"modified1\r\nline2\r\n"
+
+
+def test_editor_script_create_directory(tmpdir, run_editor):
+    import os
+
+    nested_dir = os.path.join(str(tmpdir), "new_sub_dir")
+    test_file = os.path.join(nested_dir, "test.txt")
+
+    assert not os.path.exists(nested_dir)
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        test_file,
+        "--prepend",
+        "new file content",
+    )
+
+    assert res.returncode == 0
+    assert os.path.exists(test_file)
+    with open(test_file, encoding="utf-8") as f:
+        assert f.read() == "new file content"
+
+
+def test_editor_script_no_unnecessary_write(tmpdir, run_editor):
+    import os
+    import time
+
+    test_file = tmpdir.join("test.txt")
+    test_file.write("hello world")
+
+    # Set mtime back in the past
+    past_time = time.time() - 3600
+    os.utime(str(test_file), (past_time, past_time))
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--match",
+        "not_present",
+        "--replace",
+        "something",
+    )
+
+    assert res.returncode == 0
+    # The file mtime should remain unchanged
+    assert os.path.getmtime(str(test_file)) == pytest.approx(past_time, abs=1)
+
+
+def test_editor_script_globals_function_not_found(tmpdir, run_editor):
+    test_file = tmpdir.join("test.txt")
+    test_file.write("content")
+
+    res = run_editor(
+        "--mode",
+        "regex",
+        "--file",
+        str(test_file),
+        "--function",
+        "my_edit",
+    )
+
+    assert res.returncode == 1
+    assert "Function my_edit not found" in (res.stdout + res.stderr)

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -429,7 +429,7 @@ _ramble_docs() {
 _ramble_edit() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --type -c --command -d --docs -t --test -m --module -r --repo -N --namespace"
+        RAMBLE_COMPREPLY="-h --help -t --type -r --repo -N --namespace"
     else
         RAMBLE_COMPREPLY=""
     fi


### PR DESCRIPTION
Previously for ramble `ramble edit <name>` you had to specify type. This PR makes it so if you do `ramble edit modifier_name` it will attempt to find what you mean and deduce the type 