### PR TITLE
Tutorial and documentation fixes/updates

### DIFF
--- a/examples/tutorial_8_expansion_indirection_config.yaml
+++ b/examples/tutorial_8_expansion_indirection_config.yaml
@@ -50,7 +50,7 @@ ramble:
         pkg_spec: intel-oneapi-mpi@2021.17.2
         compiler: gcc14
       openmpi:
-        pkg_spec: openmpi@5.0.8 +orterunprefix
+        pkg_spec: openmpi@5.0.8
         compiler: gcc14
       wrfv4-{application::wrf::version}:
         pkg_spec: wrf@{application::wrf::version} build_type=dm+sm compile_type=em_real

--- a/examples/tutorial_8_mpi_config.yaml
+++ b/examples/tutorial_8_mpi_config.yaml
@@ -42,7 +42,7 @@ ramble:
         pkg_spec: intel-oneapi-mpi@2021.17.2
         compiler: gcc14
       openmpi:
-        pkg_spec: openmpi@5.0.8 +orterunprefix
+        pkg_spec: openmpi@5.0.8
         compiler: gcc14
       wrfv4-{application::wrf::version}:
         pkg_spec: wrf@{application::wrf::version} build_type=dm+sm compile_type=em_real

--- a/examples/tutorial_8_mpi_matrix_config.yaml
+++ b/examples/tutorial_8_mpi_matrix_config.yaml
@@ -44,7 +44,7 @@ ramble:
         pkg_spec: intel-oneapi-mpi@2021.17.2
         compiler: gcc14
       openmpi:
-        pkg_spec: openmpi@5.0.8 +orterunprefix
+        pkg_spec: openmpi@5.0.8
         compiler: gcc14
       wrfv4-{application::wrf::version}:
         pkg_spec: wrf@{application::wrf::version} build_type=dm+sm compile_type=em_real

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -208,6 +208,7 @@ nitpicky = True
 nitpick_ignore = [
     # Python classes that intersphinx is unable to resolve
     ("py:class", "argparse.HelpFormatter"),
+    ("py:class", "callable"),
     ("py:class", "contextlib.contextmanager"),
     ("py:class", "func"),
     ("py:class", "module"),

--- a/lib/ramble/docs/dev_guides/1_basic_application_definition_tutorial.rst
+++ b/lib/ramble/docs/dev_guides/1_basic_application_definition_tutorial.rst
@@ -127,6 +127,19 @@ This defines a new executable in the hostname application definition named
 ``hostname`` command. The remaining arguments are left as the default which
 will disable MPI on this executable.
 
+.. note::
+    Throughout these tutorials the directives such as ``executable`` are
+    called using positional parameters as above. However, named parameters -
+    or even a mix of positional and named parameters - are also allowed. For
+    example, the following is identical to the above example:
+
+    .. code-block:: python
+
+        executable(
+            name="local-execute",
+            template="hostname",
+        )
+
 Application Workloads
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/ramble/docs/dev_guides/2_hpl_application_definition_tutorial.rst
+++ b/lib/ramble/docs/dev_guides/2_hpl_application_definition_tutorial.rst
@@ -128,14 +128,15 @@ HPL requires an ``HPL.dat`` input file to run. Ramble has directives for
 downloading input files from websites. However, given this is a basic text
 file, Ramble can generate this file from a template. We use the
 ``register_template`` directive to tell Ramble how to generate this file for
-us.
+us. The documentation for the ``register_template`` directive can be found at
+:py:meth:`ramble.language.shared_language.register_template`.
 
 .. code-block:: python
 
         register_template(
             "hpl.dat.in",
-            template_file="templates/HPL.dat.tpl",
-            destination="HPL.dat"
+            src_path="templates/HPL.dat.tpl",
+            dest_path="HPL.dat"
         )
 
 Now, let's populate the template file
@@ -305,8 +306,8 @@ Our complete application definition at this point is as follows:
 
         register_template(
             "hpl.dat.in",
-            template_file="templates/HPL.dat.tpl",
-            destination="HPL.dat"
+            src_path="templates/HPL.dat.tpl",
+            dest_path="HPL.dat"
         )
 
         executable(
@@ -367,6 +368,7 @@ and ranks. For HPL, the number of ranks should equal PxQ.
 .. code-block:: console
 
   $ ramble workspace manage experiments hpl --overwrite \
+      -V package_manager=spack \
       -v n_nodes=1 \
       -v n_ranks=4 \
       -v Ps=2 \
@@ -378,11 +380,14 @@ Now, to complete the test we can execute:
 
 .. code-block:: console
 
+  $ ramble workspace concretize
   $ ramble workspace setup
   $ ramble on
   $ ramble workspace analyze
 
-The ``ramble workspace setup`` command will build HPL using Spack (if not
+The ``ramble workspace concretize`` will pull the default software environment
+and package specs from the HPL application and add it to the config. The 
+``ramble workspace setup`` command will build HPL using Spack (if not
 already installed), which can take some time. Then, the ``ramble on`` command
 will run the experiment. After analysis, the result of these commands should be
 the creation of a ``results.latest.txt`` file that contains the Gflops of your

--- a/lib/ramble/docs/tutorials.rst
+++ b/lib/ramble/docs/tutorials.rst
@@ -33,5 +33,6 @@ various features.
     tutorials/mirrors
     tutorials/EESSI_package_manager
     tutorials/Workspace_config_command
+    tutorials/Workspace_manage_experiments_command
 
 

--- a/lib/ramble/docs/tutorials/4_using_vectors_and_matrices.rst
+++ b/lib/ramble/docs/tutorials/4_using_vectors_and_matrices.rst
@@ -422,17 +422,17 @@ Which should contain the following output:
 
 .. code-block:: console
 
-Experiments:
-  Application: gromacs@2025.3
-    Workload: {app_workload}
-      Experiment 1: gromacs@2025.3.water_bare.pme_1ranks
-      Experiment 2: gromacs@2025.3.water_bare.pme_2ranks
-      Experiment 3: gromacs@2025.3.water_bare.rf_1ranks
-      Experiment 4: gromacs@2025.3.water_bare.rf_2ranks
-      Experiment 5: gromacs@2025.3.water_gmx50.pme_1ranks
-      Experiment 6: gromacs@2025.3.water_gmx50.pme_2ranks
-      Experiment 7: gromacs@2025.3.water_gmx50.rf_1ranks
-      Experiment 8: gromacs@2025.3.water_gmx50.rf_2ranks
+    Experiments:
+        Application: gromacs@2025.3
+            Workload: {app_workload}
+            Experiment 1: gromacs@2025.3.water_bare.pme_1ranks
+            Experiment 2: gromacs@2025.3.water_bare.pme_2ranks
+            Experiment 3: gromacs@2025.3.water_bare.rf_1ranks
+            Experiment 4: gromacs@2025.3.water_bare.rf_2ranks
+            Experiment 5: gromacs@2025.3.water_gmx50.pme_1ranks
+            Experiment 6: gromacs@2025.3.water_gmx50.pme_2ranks
+            Experiment 7: gromacs@2025.3.water_gmx50.rf_1ranks
+            Experiment 8: gromacs@2025.3.water_gmx50.rf_2ranks
 
 .. include:: shared/gromacs_execute.rst
 

--- a/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
+++ b/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
@@ -139,7 +139,7 @@ package, you can use:
 This command will output all of the supported versions of GROMACS, along with
 the variants for GROMACS which can modify its behavior. While you can change
 any of these, we'll begin by only modifying the version of GROMACS from
-``2024.1`` to ``2024.2``.
+``2025.3`` to ``2025.4``.
 
 To make editing the workspace easier, use the following command (assuming you
 have an ``EDITOR`` environment variable set):
@@ -151,8 +151,8 @@ have an ``EDITOR`` environment variable set):
 This command opens the ``ramble.yaml`` file, along with any ``*.tpl`` files in
 the workspace's ``configs`` directory.
 
-Once the ``ramble.yaml`` file is opened, change the version ``2024.1`` to
-``2024.2`` in the ``gromacs`` package definition. Then save and exit the files.
+Once the ``ramble.yaml`` file is opened, change the version ``2025.3`` to
+``2025.4`` in the ``gromacs`` package definition. Then save and exit the files.
 These changes should now be reflected in the output of:
 
 .. code-block:: console

--- a/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
+++ b/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
@@ -94,7 +94,7 @@ like the following:
 
     packages:
       openmpi:
-        pkg_spec: openmpi@5.0.8 +orterunprefix
+        pkg_spec: openmpi@5.0.8
 
 In the definition of the Intel MPI package above, you'll see we originally
 specified a ``compiler`` attribute (with the value of ``gcc14``). This can be

--- a/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
+++ b/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
@@ -42,7 +42,8 @@ To start, create a new workspace using ``ramble workspace create``:
 
    $ ramble workspace create -d manage-workspace
 
-This creates a workspace with the default ``ramble.yaml`` configuration:
+This creates an anonymous workspace (see note below) with the default ``ramble.yaml``
+configuration:
 
 .. code-block:: yaml
 
@@ -82,10 +83,16 @@ And there are no experiments listed in the output from ``ramble -D manage-worksp
 
 .. note::
    Throughout this tutorial, we will use the ``-D manage-workspace`` flag to direct
-   commands to our new workspace without needing to activate it explicitly.
+   commands to our new anonymous workspace without needing to activate it explicitly.
+   In these examples the ``manage-workspace`` directory is relative to our current working
+   directory, but you may specify an absolute path to a workspace directory as well - e.g.,
+   ``-D ${HOME}/manage-workspace``.
+
+   For more information on named and anonymous workspaces, see the
+   :ref:`Ramble workspace documentation<ramble-workspaces>`.
 
 -------------------------------
-Generating Baseline Experiments
+Generating Default Experiments
 -------------------------------
 
 The simplest usage of ``ramble workspace manage experiments`` is to generate default

--- a/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
+++ b/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
@@ -1,0 +1,391 @@
+.. Copyright 2022-2026 The Ramble Authors
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _workspace-manage-experiments-command-tutorial:
+
+=========================================================
+Using the ``ramble workspace manage experiments`` Command
+=========================================================
+
+Ramble workspaces are controlled through their configuration files. Each workspace has a
+configuration file stored at ``$workspace/configs/ramble.yaml``. Definitions for the
+Ramble experiments you want to perform come from this configuration file. While you can
+write and edit these YAML files manually, Ramble provides a command-line interface
+to generate and manage experiment definitions programmatically:
+``ramble workspace manage experiments``.
+
+This command is used throughout Ramble's developer tutorials to quickly bootstrap
+experiments, construct parameter sweeps, and automate workspace generation without
+hand-crafting YAML boilerplate.
+
+In this tutorial, you will learn how to use ``ramble workspace manage experiments`` to:
+
+* Generate baseline experiment configurations for applications and workloads.
+* Filter workloads to include only the test cases you need.
+* Inject and parameterize variables for scaling studies and sweeps.
+* Define matrices to expand multi-variable combinations.
+* Apply variants (such as specifying a package manager).
+* Perform dry runs to preview generated configurations before saving.
+
+--------------------
+Creating a Workspace
+--------------------
+
+To start, create a new workspace using ``ramble workspace create``:
+
+.. code-block:: console
+
+   $ ramble workspace create -d manage-workspace
+
+This creates a workspace with the default ``ramble.yaml`` configuration:
+
+.. code-block:: yaml
+
+    # This is a ramble workspace config file.
+    #
+    # It describes the experiments, the software stack
+    # and all variables required for ramble to configure
+    # experiments.
+    # As an example, experiments can be defined as follows.
+    # applications:
+    #   hostname: # Application name, as seen in `ramble list`
+    #     variables:
+    #       iterations: '5'
+    #     workloads:
+    #       serial: # Workload name, as seen in `ramble info <app>`
+    #         variables:
+    #           type: 'test'
+    #         experiments:
+    #           single_node: # Arbitrary experiment name
+    #             variables:
+    #               n_ranks: '{processes_per_node}'
+
+    ramble:
+    env_vars:
+        set:
+        OMP_NUM_THREADS: '{n_threads}'
+    variants:
+        system: user-managed
+    variables:
+        processes_per_node: 1
+    applications: {}
+    software: 
+        packages: {}
+        environments: {}
+
+And there are no experiments listed in the output from ``ramble -D manage-workspace workspace info``.
+
+.. note::
+   Throughout this tutorial, we will use the ``-D manage-workspace`` flag to direct
+   commands to our new workspace without needing to activate it explicitly.
+
+-------------------------------
+Generating Baseline Experiments
+-------------------------------
+
+The simplest usage of ``ramble workspace manage experiments`` is to generate default
+experiment definitions for an application.
+
+Let's generate experiments for the ``hostname`` application:
+
+.. code-block:: console
+
+   $ ramble -D manage-workspace workspace manage experiments hostname --overwrite
+
+Here, the ``--overwrite`` flag tells Ramble to replace any existing experiment
+definitions for the ``hostname`` application in the workspace configuration file.
+
+You can inspect the resulting workspace state using the ``workspace info`` command:
+
+.. code-block:: console
+
+   $ ramble -D manage-workspace workspace info
+
+The ``hostname`` application has four defined workloads so the output should look
+like the following:
+
+.. code-block:: console
+
+    Experiments:
+        Application: hostname
+            Workload: serial
+            Experiment 1: hostname.serial.generated
+        Application: hostname
+            Workload: parallel
+            Experiment 2: hostname.parallel.generated
+        Application: hostname
+            Workload: local
+            Experiment 3: hostname.local.generated
+        Application: hostname
+            Workload: local_bg
+            Experiment 4: hostname.local_bg.generated
+
+Ramble generated an experiment for each of the workloads. The ``ramble.yaml``
+configuration should also now look like:
+
+.. code-block:: yaml
+
+    # This is a ramble workspace config file.
+    #
+    # It describes the experiments, the software stack
+    # and all variables required for ramble to configure
+    # experiments.
+    # As an example, experiments can be defined as follows.
+    # applications:
+    #   hostname: # Application name, as seen in `ramble list`
+    #     variables:
+    #       iterations: '5'
+    #     workloads:
+    #       serial: # Workload name, as seen in `ramble info <app>`
+    #         variables:
+    #           type: 'test'
+    #         experiments:
+    #           single_node: # Arbitrary experiment name
+    #             variables:
+    #               n_ranks: '{processes_per_node}'
+
+    ramble:
+    env_vars:
+        set:
+        OMP_NUM_THREADS: '{n_threads}'
+    variants:
+        system: user-managed
+    variables:
+        processes_per_node: 1
+    applications:
+        hostname:
+        workloads:
+            serial:
+            experiments:
+                generated:
+                variables:
+                    n_nodes: ''
+                    n_ranks: ''
+            parallel:
+            experiments:
+                generated:
+                variables:
+                    n_nodes: ''
+                    n_ranks: ''
+            local:
+            experiments:
+                generated:
+                variables:
+                    n_nodes: ''
+                    n_ranks: ''
+            local_bg:
+            experiments:
+                generated:
+                variables:
+                    n_nodes: ''
+                    n_ranks: ''
+    software:
+        packages: {}
+        environments: {}
+
+You'll notice that the ``n_nodes`` and ``n_ranks`` variables have no values, this
+will be covered next.
+
+------------------------------------------
+Filtering Workloads and Setting Variables
+------------------------------------------
+
+Often, an application contains multiple workloads, but you may only want to test a
+specific one. You can use the ``--workload-filter`` (or ``--wf``) option to restrict
+which workloads are generated.
+
+Additionally, you can pass variable definitions using ``--variable-definition`` (or ``-v``)
+in ``key=value`` format.
+
+Let's generate a ``hostname`` experiment restricted to the ``local`` workload with
+custom variables. But first, because ``workspace manage experiments`` does not
+remove existing configuration, only add new experiments or overwrite existing
+experiments, let's remove the extra workloads. Use
+``ramble -D manage-workspace workspace edit -c`` to make the configuration look like
+the following:
+
+.. code-block:: yaml
+
+    # This is a ramble workspace config file.
+    #
+    # It describes the experiments, the software stack
+    # and all variables required for ramble to configure
+    # experiments.
+    # As an example, experiments can be defined as follows.
+    # applications:
+    #   hostname: # Application name, as seen in `ramble list`
+    #     variables:
+    #       iterations: '5'
+    #     workloads:
+    #       serial: # Workload name, as seen in `ramble info <app>`
+    #         variables:
+    #           type: 'test'
+    #         experiments:
+    #           single_node: # Arbitrary experiment name
+    #             variables:
+    #               n_ranks: '{processes_per_node}'
+
+    ramble:
+    env_vars:
+        set:
+        OMP_NUM_THREADS: '{n_threads}'
+    variants:
+        system: user-managed
+    variables:
+        processes_per_node: 1
+    applications:
+        hostname:
+        workloads:
+            local:
+            experiments:
+                generated:
+                variables:
+                    n_ranks: ''
+                    n_nodes: ''
+    software:
+        packages: {}
+        environments: {}
+
+All the workloads except the ``local`` workload have now been removed. Now let's
+update the ``local`` workload to define the desired variable values.
+
+.. code-block:: console
+
+   $ ramble -D manage-workspace workspace manage experiments hostname \
+        --wf local \
+        -v n_ranks=1 \
+        -v n_nodes=1 \
+        --overwrite
+
+Inspecting ``manage-workspace/configs/ramble.yaml`` shows the updated configuration:
+
+.. code-block:: yaml
+
+   ramble:
+     applications:
+       hostname:
+         workloads:
+           local:
+             experiments:
+               generated:
+                 variables:
+                   n_nodes: '1'
+                   n_ranks: '1'
+
+---------------------------------------------------
+Configuring Parameter Sweeps (Vectors and Matrices)
+---------------------------------------------------
+
+To set up scaling studies or multi-dimensional parameter sweeps, you can pass vector
+lists into variable definitions and define a matrix with ``--matrix`` (or ``-m``).
+
+When expanding a matrix into multiple experiments, each experiment requires a unique name.
+You can specify a template for experiment names using ``--experiment-name`` (or ``-e``),
+interpolating variable values like ``'{size}-{n_nodes}nodes'``.
+
+Let's add experiments for the ``gromacs`` application, filtering for the ``water_bare`` workload,
+sweeping over node counts and domain sizes:
+
+.. code-block:: console
+
+   $ ramble -D manage-workspace workspace manage experiments gromacs \
+        --wf water_bare \
+        -v "n_nodes=[1, 2, 4]" \
+        -v "size=[1536, 3072]" \
+        -m n_nodes,size \
+        -e '{size}-{n_nodes}nodes' \
+        -V package_manager=spack
+
+Let's break down the options used in this command:
+
+* ``--wf water_bare``: Restricts experiment generation to the ``water_bare`` workload.
+* ``-v "n_nodes=[1, 2, 4]"`: Sets ``n_nodes`` as a vector of node counts.
+* ``-v "size=[1536, 3072]"`: Sets ``size`` as a vector of problem sizes.
+* ``-m n_nodes,size``: Defines a matrix across ``n_nodes`` and ``size``.
+* ``-e '{size}-{n_nodes}nodes'``: Formats experiment names dynamically based on variable values.
+* ``-V package_manager=spack``: Adds a variant definition setting the package manager to Spack.
+
+Now check the workspace info again:
+
+.. code-block:: console
+
+   $ ramble -D manage-workspace workspace info
+
+Output:
+
+.. code-block:: console
+
+    Experiments:
+    Application: hostname
+        Workload: local
+        Experiment 1: hostname.local.generated
+    Application: gromacs
+        Workload: water_bare
+        Experiment 2: gromacs.water_bare.1536-1nodes
+        Experiment 3: gromacs.water_bare.3072-1nodes
+        Experiment 4: gromacs.water_bare.1536-2nodes
+        Experiment 5: gromacs.water_bare.3072-2nodes
+        Experiment 6: gromacs.water_bare.1536-4nodes
+        Experiment 7: gromacs.water_bare.3072-4nodes
+
+Ramble automatically generated 6 distinct experiments representing the cross-product
+of 3 node counts and 2 problem sizes.
+
+---------------------------------------
+Previewing Configurations with Dry Runs
+---------------------------------------
+
+Before modifying your workspace configuration, you can perform a dry run using ``--dry-run``
+(or ``--print``). This is especially helpful when scripting or testing complex matrix
+combinations. This prints the resulting YAML configuration to stdout without saving changes
+to disk:
+
+.. code-block:: console
+
+   $ ramble -D manage-workspace workspace manage experiments hostname \
+        --wf local \
+        -v n_ranks=4 \
+        --overwrite \
+        --dry-run
+
+A few things to note:
+
+1. If the experiment already exists, ``--overwrite`` must be used or you will get an error
+like:
+
+.. code-block:: console
+
+    ==> Warning: Experiment hostname.local.generated is defined already. To overwrite, use '--overwrite'
+    ==> Error: No workloads match filter 'local' in application hostname
+
+2. You'll notice from the dry run output that ``n_nodes`` was reset to no value. That's
+because no value was provided so it reverted back to the default.
+
+-------------------
+Where to Learn More
+-------------------
+
+The ``ramble workspace manage experiments`` command offers additional options and customization
+details. To explore further, consult the following resources:
+
+* **Command Line Help**: Run ``ramble workspace manage experiments --help`` for a full summary of flags and arguments.
+* **Developer Guides**: See the :ref:`application-dev-guide` and developer tutorials (e.g. :ref:`basic_application_tutorial`) to see how ``manage experiments`` is used when creating and testing new object definitions.
+
+----------------------
+Conclusion and Cleanup
+----------------------
+
+In this tutorial, you learned how to use ``ramble workspace manage experiments`` to programmatically
+create baseline experiments, filter workloads, set variables, construct matrix sweeps, set variants,
+and dry-run experiment configurations.
+
+To clean up the tutorial workspace, run:
+
+.. code-block:: console
+
+   $ rm -rf manage-workspace

--- a/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
+++ b/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
@@ -204,7 +204,7 @@ in ``key=value`` format.
 
 Let's generate a ``hostname`` experiment restricted to the ``local`` workload with
 custom variables. But first, because ``workspace manage experiments`` does not
-remove existing configuration, only add new experiments or overwrite existing
+remove existing configuration, only adds new experiments or overwrite existing
 experiments, let's remove the extra workloads. Use
 ``ramble -D manage-workspace workspace edit -c`` to make the configuration look like
 the following:
@@ -276,6 +276,18 @@ Inspecting ``manage-workspace/configs/ramble.yaml`` shows the updated configurat
                  variables:
                    n_nodes: '1'
                    n_ranks: '1'
+
+.. note::
+    If you are setting all the required variables to the same value, you can
+    instead use ``--default-variable-value <value>`` instead of specifying each
+    individual variable. So the above could have been replaced with:
+
+    .. code-block:: console
+
+        $ ramble -D manage-workspace workspace manage experiments hostname \
+                --wf local \
+                --default-variable-value 1 \
+                --overwrite
 
 ---------------------------------------------------
 Configuring Parameter Sweeps (Vectors and Matrices)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1493,7 +1493,8 @@ def workspace_manage_experiments_setup_parser(subparser):
         "-p",
         dest="package_manager",
         default=None,
-        help="(DEPRECATED) name of (optional) package manager to use within the experiment scope",
+        help="(DEPRECATED) name of (optional) package manager to use within the experiment scope. "
+        + "Use --variant-definition/-V package_manager=PACKAGE_MANAGER, instead",
     )
 
     # TODO: remove in 0.7.0
@@ -1502,7 +1503,8 @@ def workspace_manage_experiments_setup_parser(subparser):
         "--wm",
         dest="workflow_manager",
         default=None,
-        help="(DEPRECATED) name of (optional) workflow manager to use within the experiment scope",
+        help="(DEPRECATED) name of (optional) workflow manager to use within the experiment "
+        + "scope. Use --variant-definition/-V workflow_manager=WORKFLOW_MANAGER, instead",
     )
 
     subparser.add_argument(

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -635,7 +635,7 @@ class Configuration:
             ValueError: if ``scope`` is not valid
 
         Returns:
-            ConfigScope: a valid ConfigScope if ``scope`` is ``None`` or valid
+            ramble.config.ConfigScope: A valid ConfigScope if ``scope`` is ``None`` or valid
         """
         if scope is None:
             # default to the scope with highest precedence.
@@ -1378,7 +1378,7 @@ def _update_in_memory(data, section):
         section (str): section of the configuration to update
 
     Returns:
-        True if the data was changed, False otherwise
+        bool: ``True`` if the data was changed, ``False`` otherwise
     """
     update_fn = ensure_latest_format_fn(section)
     changed = update_fn(data[section])
@@ -1411,7 +1411,8 @@ def use_configuration(*scopes_or_paths):
         *scopes_or_paths: scope objects or paths to be used
 
     Returns:
-        Configuration object associated with the scopes passed as arguments
+        ramble.config.Configuration: Configuration object associated with the scopes
+        passed as arguments
     """
     global config
 

--- a/lib/ramble/ramble/definitions/variables.py
+++ b/lib/ramble/ramble/definitions/variables.py
@@ -69,10 +69,11 @@ class Variable:
         """String representation of this variable
 
         Args:
-          n_indent (int): Number of spaces to indent string lines with
+            n_indent (int): Number of spaces to indent string lines with
+            verbose (bool): Whether to include verbose information about the variable
 
         Returns:
-            (str): Representation of this variable
+            str: Representation of this variable
         """
         indentation = " " * n_indent
 
@@ -229,10 +230,11 @@ class VariableModification:
         """String representation of this variable
 
         Args:
-          n_indent (int): Number of spaces to indent string lines with
+            n_indent (int): Number of spaces to indent string lines with
+            verbose (bool): Whether to include verbose information about the variable
 
         Returns:
-            (str): Representation of this variable
+            str: Representation of this variable
         """
         indentation = " " * n_indent
 
@@ -301,9 +303,11 @@ class EnvironmentVariable:
 
         Args:
             n_indent (int): Number of spaces to indent string representation by
+            verbose (bool): Whether to include verbose information about the
+                            environment variable
 
         Returns:
-            (str): String representing this environment variable
+            str: String representing this environment variable
         """
         indentation = " " * n_indent
 
@@ -382,10 +386,12 @@ class EnvironmentVariableModifications:
         """String representation of this environment variable modification
 
         Args:
-          n_indent (int): Number of spaces to indent string lines with
+            n_indent (int): Number of spaces to indent string lines with
+            verbose (bool): Whether to include verbose information about the
+                            environment variable modification
 
         Returns:
-            (str): Representation of this environment variable modification
+            str: Representation of this environment variable modification
         """
         indentation = " " * n_indent
 

--- a/lib/ramble/ramble/definitions/versions.py
+++ b/lib/ramble/ramble/definitions/versions.py
@@ -84,10 +84,10 @@ class ObjectVersion:
 
         Args:
             n_indent (int): Number of spaces to indent string with
-            verbose: Print verbose
+            verbose (bool): Whether to include verbose information about the version
 
         Returns:
-            (str): Representation of this version
+            str: Representation of this version
         """
         indentation = " " * n_indent
         out_str = color.section_title(f"{indentation}{self.version}") + "\n"
@@ -135,8 +135,8 @@ class ObjectVersion:
             variant: A version variant containing the "@" sigil
 
         Returns:
-            (bool): True or False, based if the experiment's variant satisfies
-                    the version
+            bool: ``True`` or ``False``, based if the experiment's variant satisfies
+            the version
         """
         # Convert the variant syntax to a python packaging specifier set
         variant_name, value = variant.split("@")

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -927,8 +927,8 @@ class Expander:
           replace_escaped_braces (bool): Whether escaped curly braces are replaced
                                          as part of expansion or not.
 
-        returns:
-          str: Expanded version of ``in_str``
+        Returns:
+            str: Expanded version of ``in_str``
         """
 
         if replace_escaped_braces is None:

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -279,7 +279,7 @@ class ExpansionNode:
             relative_to (ExpansionNode): node to shift current node's indices relative to
 
         Returns:
-            (tuple) indices of shifted match set
+            tuple: indices of shifted match set
         """
         return (self.left - relative_to.left, self.right - relative_to.left)
 
@@ -832,7 +832,7 @@ class Expander:
             extra_vars: Variable definitions to use with highest precedence
 
         Returns:
-            bool: True or False, based on the evaluation of in_str
+            bool: ``True`` or ``False`` based on the evaluation of ``in_str``
         """
 
         evaluated = self.expand_var(
@@ -871,8 +871,8 @@ class Expander:
                                set of used variables or not.
 
         Returns:
-            (bool): True or False, based if the experiment's variants satisfy
-                     the input requirement.
+            bool: ``True`` or ``False`` based if the experiment's variants satisfy
+            the input requirement.
         """
         if reqs is None:
             return True
@@ -928,7 +928,7 @@ class Expander:
                                          as part of expansion or not.
 
         returns:
-          in_str (str): Expanded version of input string
+          str: Expanded version of ``in_str``
         """
 
         if replace_escaped_braces is None:
@@ -967,7 +967,7 @@ class Expander:
             in_str (str): string representing math to attempt to evaluate
 
         Returns:
-            (str) either the evaluation of in_str (if successful) or in_str
+            str: either the evaluation of ``in_str`` (if successful) or ``in_str``
             unmodified (if unsuccessful)
 
         """

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -267,7 +267,7 @@ class ExperimentSet:
             repeats (Repeats): Repeats object for this experiment
 
         Returns:
-            (Application): Instance of an application class for this experiment
+            list: Instance of an application class for this experiment
         """
 
         experiment_suffix = ""
@@ -460,7 +460,7 @@ class ExperimentSet:
             chained (bool): Whether the experiments are chained experiments or not
 
         Returns:
-            (list): List of application instances from the rendered set of experiments
+            list: List of application instances from the rendered set of experiments
         """
         app_context = ramble.context.Context()
         app_context.context_name = app_name
@@ -495,7 +495,7 @@ class ExperimentSet:
                             experiments list.
 
         Returns:
-            (list): List of application instances that are rendered
+            list: List of application instances that are rendered
         """
 
         no_var_contexts = [
@@ -861,7 +861,7 @@ class ExperimentSet:
         """Aggregate all tags from experiments in this experiment set
 
         Returns:
-            (set): A set of all tags from the experiment set.
+            set[str]: A set of all tags from the experiment set.
         """
         all_tags = set()
         for _, inst, _ in self.all_experiments():

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -267,7 +267,7 @@ class ExperimentSet:
             repeats (Repeats): Repeats object for this experiment
 
         Returns:
-            list: Instance of an application class for this experiment
+            app_inst: Instance of an application class for this experiment
         """
 
         experiment_suffix = ""

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -130,7 +130,7 @@ class FetchStrategy:
         """Fetch source code archive or repo.
 
         Returns:
-            bool: True on success, False on failure.
+            bool: ``True`` on success, ``False`` on failure.
         """
 
     def check(self):
@@ -161,7 +161,7 @@ class FetchStrategy:
         identifiably associated with a specific package version.
 
         Returns:
-            bool: True if can cache, False otherwise.
+            bool: ``True`` if can cache, ``False`` otherwise.
         """
 
     def source_id(self):
@@ -1246,7 +1246,7 @@ class HgFetchStrategy(VCSFetchStrategy):
     def hg(self):
         """
         Returns:
-            Executable: the hg executable
+            ramble.util.executable.Executable: the hg executable
         """
         if not self._hg:
             self._hg = which("hg", required=True)
@@ -1429,11 +1429,11 @@ def from_kwargs(**kwargs):
             ``version()`` directive in a package.
 
     Returns:
-        FetchStrategy: The fetch strategy that matches the args, based
-          on attribute names (e.g., ``git``, ``hg``, etc.)
+        ramble.fetch_strategy.FetchStrategy: The fetch strategy that matches the args,
+        based on attribute names (e.g., ``git``, ``hg``, etc.)
 
     Raises:
-        FetchError: If no ``fetch_strategy`` matches the args.
+        ramble.fetch_strategy.FetchError: If no ``fetch_strategy`` matches the args.
     """
     for fetcher in all_strategies:
         if fetcher.matches(kwargs):

--- a/lib/ramble/ramble/graphs.py
+++ b/lib/ramble/ramble/graphs.py
@@ -145,8 +145,8 @@ class AttributeGraph:
             key (str): Name of key to find in the graph
 
         Returns:
-            (ramble.util.graph.GraphNode): Node representing the key
-                requested. Returns None if the key isn't found.
+            ramble.util.graph.GraphNode | None: Node representing the key requested or
+            ``None`` if the key isn't found.
         """
         node = self.node_definitions.get(key)
         if node is not None and node in self.adj_list:

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -161,22 +161,20 @@ def executable(name, template, when=None, **kwargs):
 
     Executables may or may not use MPI.
 
-    Required Args:
+    Args:
         name (str): Name of the executable
         template (list[str] | str): The template command this executable should generate from
-
-    Optional Args:
-        use_mpi or mpi (bool): determines if this executable should be
-                        wrapped with an `mpirun` like command or not.
-
+        use_mpi (bool): determines if this executable should be
+            wrapped with an `mpirun` like command or not
+        mpi (bool): Alias for ``use_mpi``
         variables (dict): Dictionary of variable definitions to use for this
-                          executable only
+            executable only
         redirect (str): Optional, sets the path for outputs to be written to.
-                             defaults to {log_file}
+            defaults to {log_file}
         output_capture (str): Optional, Declare which output (stdout, stderr,
-                              both) to capture. Defaults to stdout
+            both) to capture. Defaults to stdout
         run_in_background (bool): Optional, Declare if the command should
-                                     run in the background. Defaults to False
+            run in the background. Defaults to False
         when (list | None): List of when conditions to apply to directive
     """
 
@@ -214,6 +212,7 @@ def input_file(
     fetched from.
 
     Args:
+        name (str): Name of the input file
         url (str): Path to the input file / archive
         description (str): Description of this input file
         target_dir (str): Optional, the directory where the archive will be

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -30,9 +30,6 @@ def check_definition(
         single_arg_name: String name of the single_type argument in the directive
         multiple_arg_name: String name of the multiple_type argument in the directive
         directive_name: Name of the directive requiring a type
-
-    Returns:
-        List of all type names (Merged if both single_type and multiple_type definitions are valid)
     """
     if single_type and not isinstance(single_type, str):
         raise DirectiveError(
@@ -71,7 +68,8 @@ def merge_definitions(
         directive_name: Name of the directive requiring a type
 
     Returns:
-        List of all type names (Merged if both single_type and multiple_type definitions are valid)
+        list[str]: List of all type names (Merged if both ``single_type`` and ``multiple_type``
+        definitions are valid)
     """
 
     check_definition(
@@ -115,7 +113,8 @@ def require_definition(
         directive_name: Name of the directive requiring a type
 
     Returns:
-        List of all type names (Merged if both single_type and multiple_type definitions are valid)
+        list[str]: List of all type names (Merged if both single_type and multiple_type
+        definitions are valid)
     """
 
     if not (single_type or multiple_type):
@@ -159,7 +158,8 @@ def merge_conditions(
         modes (list(str) | None): List of modifier modes to be applied as when conditions
 
     Returns:
-        List of lists of strings, where each inner list is a list of when conditions for a mode.
+        list[list[str]]:List of lists of strings, where each inner list is a list of when
+        conditions for a mode.
     """
     single_arg_val = kwargs.get(single_arg_name) if single_arg_name else None
     multiple_arg_val = kwargs.get(multiple_arg_name) if multiple_arg_name else None
@@ -215,8 +215,8 @@ def expand_patterns(merged_types: list, multiple_pattern_match: Union[list, dict
             dict) to match against patterns in merged_types
 
     Returns:
-        List of expanded patterns matching the names list plus patterns
-            not found in the names list.
+        list[str]: List of expanded patterns matching the names list plus
+        patterns not found in the names list.
     """
     expanded_patterns = OrderedDict()
     for input in merged_types:
@@ -290,7 +290,7 @@ def build_when_list(
         directive_name (str): Name of the calling directive
 
     Returns:
-        List of strings, for all of the when conditions.
+        list[str]: List of strings for all of the when conditions.
     """
     when_list = []
     if when_arg is not None:
@@ -473,7 +473,7 @@ def are_when_compatible(when_set1, when_set2):
         when_set2 (list): Second set of when conditions
 
     Returns:
-        (bool): True if they are compatible, False otherwise
+        bool: True if they are compatible, False otherwise
     """
     if not isinstance(when_set1, frozenset):
         when_set1 = frozenset(when_set1)
@@ -504,7 +504,7 @@ def is_when_impossible(when_list):
         when_list (list): list of when conditions
 
     Returns:
-        (bool, str): True and a message if it is impossible, False and None otherwise
+        tuple[bool, str | None]: True and a message if it is impossible, False and None otherwise
     """
     if when_list is None:
         return False, None

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -174,10 +174,11 @@ def executable_modifier(name, usage_filter=None, when=None, **kwargs):
         when (list | None): List of when conditions this executable modifier should apply in
 
     Each executable modifier needs to return:
-      prepend_execs (list(CommandExecutable)): List of executables to inject
-                                               before the base executable
-      append_execs (list(CommandExecutable)): List of executables to inject
-                                              after the base executable
+
+     * **prepend_execs (list(CommandExecutable)):** List of executables to inject
+       before the base executable
+     * **append_execs (list(CommandExecutable)):** List of executables to inject
+       after the base executable
     """
 
     def _executable_modifier(mod):

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -105,11 +105,9 @@ def edit_file(
 
     Defines a new executable that uses Ramble's helper script to edit a file.
 
-    Required Args:
+    Args:
         name (str): Name of the executable
         file_path (str): Path to the file to edit
-
-    Optional Args:
         match (str): Regex pattern to match
         replace (str): Replacement string
         append (str): String to append to the end of the file
@@ -244,12 +242,10 @@ def patch_file(
 
     Defines a new executable that uses Ramble's helper script to apply a patch.
 
-    Required Args:
+    Args:
         name (str): Name of the executable
         file_path (str): Path to the file to patch
         patch_file (str): Path to the patch file
-
-    Optional Args:
         fail_on_error (bool): If true, the experiment fails if the patch fails.
                               Defaults to True.
         when (list | None): List of when conditions to apply to directive

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -704,7 +704,7 @@ class RambleCommand:
                 simulates ``ramble [global_args] [command] [*argv]``
 
         Returns:
-            (str): combined output and error as a string
+            str: combined output and error as a string
 
         On return, if ``fail_on_error`` is False, return value of command
         is set in ``returncode`` property, and the error is set in the
@@ -861,7 +861,7 @@ def resolve_alias(cmd_name, cmd):
         cmd: command line arguments.
 
     Returns:
-        new command name and arguments.
+        tuple[str, list[str]]: new command name and arguments.
     """
     all_commands = ramble.cmd.all_commands()
     aliases = ramble.config.get("config:aliases")

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -84,11 +84,11 @@ class RenderGroup:
             }
 
         Args:
-            name_template: The name template for the objects this group represents
-            in_dict: A dictionary representing the group definitions
+            name_template (str): The name template for the objects this group represents
+            in_dict (dict): A dictionary representing the group definitions
 
         Returns:
-            bool: True if anything was extracted from the dictionary
+            bool: ``True`` if anything was extracted from the dictionary
         """
 
         extracted = False

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -476,14 +476,15 @@ def extract_data(experiments: List[dict], foms: List[str], variables: List[str],
     """Extracts data from the experiments dicts and returns it as a Pandas DataFrame.
 
     Args:
-        experiments: List of experiment dictionaries containing results to extract
-        foms: List of FOMs to extract from experiments
-        variables: List of variables to extract from experiments
-        where_query: Pandas query to constrain results
+        experiments (list[dict]): List of experiment dictionaries containing results to extract
+        foms (list[str]): List of FOMs to extract from experiments
+        variables (list[str]): List of variables to extract from experiments
+        where_query (str | None): Pandas query to constrain results
 
     Returns:
-        Pandas DataFrame containing extracted data
+        pandas.core.frame.DataFrame: Pandas DataFrame containing extracted data
     """
+    pd = import_pandas()
     extracted_data = []
     for exp in experiments:
         for context in exp["CONTEXTS"]:

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -324,7 +324,7 @@ def use_repositories(*paths_and_repos, object_type=default_type):
             already constructed Repo objects
 
     Returns:
-        Corresponding RepoPath object
+        RepoPath: Corresponding RepoPath object
     """
     global paths  # noqa: F824
 
@@ -530,8 +530,7 @@ class Indexer(metaclass=abc.ABCMeta):
         """Whether an update is needed when the application file hasn't changed.
 
         Returns:
-            (bool): ``True`` if this application needs its index
-                updated, ``False`` otherwise.
+            bool: ``True`` if this application needs its index updated, ``False`` otherwise.
 
         We already automatically update indexes when object files
         change, but other files (like patches) may change underneath the

--- a/lib/ramble/ramble/results_table.py
+++ b/lib/ramble/ramble/results_table.py
@@ -68,7 +68,7 @@ class ResultsColumn:
             app_inst: Instance of an application class to expand name with
 
         Returns:
-            (str): Expanded column name
+            str: Expanded column name
         """
         return app_inst.expander.expand_var(self.name)
 
@@ -250,7 +250,7 @@ class ResultsTable:
             app_inst: Instance of an application class
 
         Returns:
-            (str): Name of table
+            str: Name of table
         """
 
         return app_inst.expander.expand_var(self.name)
@@ -277,7 +277,7 @@ class ResultsTable:
             app_inst: Instance of an application class
 
         Returns:
-            (bool): True if the app_inst is included in table, False otherwise
+            bool: ``True`` if the app_inst is included in table, ``False`` otherwise
         """
 
         include_experiment = True
@@ -507,7 +507,7 @@ class ResultsTables:
                                assuming table schema from tables.py
 
         Returns:
-            (ResultsTable): New table instance
+            ramble.results_table.ResultsTable: New table instance
         """
         new_table = ResultsTable(table_conf)
         self.table_templates.append(new_table)

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -67,7 +67,7 @@ class SoftwarePackage:
         """Return if this package is used or not
 
         Returns:
-            (bool): Whether package is used or not
+            bool: Whether package is used or not
         """
         return self._used
 
@@ -83,7 +83,7 @@ class SoftwarePackage:
                                 different.
 
         Returns:
-            (str): String representation of the spec for this package definition
+            str: String representation of the spec for this package definition
         """
 
         return ""
@@ -100,7 +100,7 @@ class SoftwarePackage:
             only_used (bool): Whether to only track used info (True) or all info (False)
 
         Returns:
-            (str): String representation of this package
+            str: String representation of this package
         """
 
         # Don't print if it is unused and we are only interested in used packages
@@ -121,7 +121,7 @@ class SoftwarePackage:
         """String representation of software package
 
         Returns:
-            (str): String representation of this software package
+            str: String representation of this software package
         """
 
         return self.info()
@@ -133,7 +133,7 @@ class SoftwarePackage:
             other (SoftwarePackage): Package to compare with self.
 
         Returns:
-            (bool): True if packages are the same, False otherwise
+            bool: ``True`` if packages are the same, ``False`` otherwise
         """
 
         return (
@@ -188,7 +188,7 @@ class RenderedPackage(SoftwarePackage):
                                 different.
 
         Returns:
-            (str): String representation of the spec for this package definition
+            str: String representation of the spec for this package definition
         """
         if not all_packages:
             all_packages = defaultdict(dict)
@@ -208,7 +208,7 @@ class RenderedPackage(SoftwarePackage):
             only_used (bool): Whether to only track used info (True) or all info (False)
 
         Returns:
-            (str): String representation of this package
+            str: String representation of this package
         """
 
         # Don't print if it is unused and we are only interested in used packages
@@ -257,7 +257,7 @@ class TemplatePackage(SoftwarePackage):
         used.
 
         Returns:
-            (bool): Whether this template contains any used packages or not
+            bool: Whether this template contains any used packages or not
         """
         for pkgs in self._rendered_packages.values():
             for pkg in pkgs.values():
@@ -277,7 +277,7 @@ class TemplatePackage(SoftwarePackage):
             only_used (bool): Whether to only track used info (True) or all info (False)
 
         Returns:
-            (str): String representation of this package
+            str: String representation of this package
         """
 
         # Don't print if it is unused and we are only interested in used packages
@@ -317,7 +317,7 @@ class TemplatePackage(SoftwarePackage):
                 package from this template
 
         Returns:
-            (SoftwarePackage): Rendered SoftwarePackage
+            ramble.software_environments.SoftwarePackage: Rendered SoftwarePackage
         """
         name = expander.expand_var(self.name, merge_used_stage=False)
         pm_name = package_manager.name
@@ -403,7 +403,7 @@ class SoftwareEnvironment:
         """Determine if environment is used or not
 
         Returns:
-            (bool): Whether environment is used or not
+            bool: Whether environment is used or not
         """
         return self._used
 
@@ -425,7 +425,7 @@ class SoftwareEnvironment:
             only_used (bool): Whether to only track used info (True) or all info (False)
 
         Returns:
-            (str): information of this environment
+            str: information of this environment
         """
 
         # Don't print if it is unused and we are only interested in used packages
@@ -451,7 +451,7 @@ class SoftwareEnvironment:
         """String representation of this environment
 
         Returns:
-            (str): Representation of this environment
+            str: Representation of this environment
         """
         return self.info(indent=0)
 
@@ -470,7 +470,7 @@ class SoftwareEnvironment:
             other (SoftwareEnvironment): Environment to compare with self
 
         Returns:
-            (bool): True if environments are equivalent, False otherwise
+            bool: ``True`` if environments are equivalent, ``False`` otherwise
         """
         if not self.name == other.name:
             return False
@@ -552,7 +552,7 @@ class TemplateEnvironment(SoftwareEnvironment):
         """Determine if TemplateEnvironment is used or not
 
         Returns:
-            (bool): Whether template environment is used or not
+            bool: Whether template environment is used or not
         """
         for envs in self._rendered_environments.values():
             for env in envs.values():
@@ -575,7 +575,7 @@ class TemplateEnvironment(SoftwareEnvironment):
             only_used (bool): Whether to only track used info (True) or all info (False)
 
         Returns:
-            (str): information of this environment
+            str: information of this environment
         """
 
         # Don't print if it is unused and we are only interested in used packages
@@ -609,7 +609,7 @@ class TemplateEnvironment(SoftwareEnvironment):
         """String representation of this environment
 
         Returns:
-            (str): String representation of this environment (none of its rendered environments)
+            str: String representation of this environment (none of its rendered environments)
         """
 
         return super().info()
@@ -629,7 +629,7 @@ class TemplateEnvironment(SoftwareEnvironment):
             package_manager: Package manager the environment is rendered with
 
         Returns:
-            (RenderedEnvironment) Reference to the rendered SoftwareEnvironment
+            RenderedEnvironment: Reference to the rendered SoftwareEnvironment
         """
         name = expander.expand_var(self.name)
         pm_name = package_manager.name
@@ -733,7 +733,7 @@ class SoftwareEnvironments:
             only_used (bool): Whether to only track used info (True) or all info (False)
 
         Returns:
-            (str): Representation of all packages and environments
+            str: Representation of all packages and environments
         """
         out_str = ""
         for pkg in self._package_templates.values():
@@ -787,7 +787,7 @@ class SoftwareEnvironments:
         """String representation of all packages and environments in this object
 
         Returns:
-            (str): Representation of all packages and environments
+            str: Representation of all packages and environments
         """
         return self.info(indent=0)
 
@@ -1015,8 +1015,8 @@ class SoftwareEnvironments:
             package_manager: Package manager the environment is rendered with
 
         Returns:
-            (SoftwareEnvironment): Reference to software environment for
-                                   the experiment
+            ramble.software_environments.SoftwareEnvironment: Reference to software environment
+            for the experiment
         """
 
         pm_name = package_manager.name

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -178,7 +178,7 @@ class InputStage:
         Entering a stage context will create the stage directory
 
         Returns:
-            self
+            InputStage: self
         """
         if self._lock is not None:
             self._lock.acquire_write(timeout=60)
@@ -195,7 +195,7 @@ class InputStage:
             exc_tb: exception traceback
 
         Returns:
-            Boolean
+            bool: Always returns ``False`` to prevent exception suppression
         """
         if self._lock is not None:
             self._lock.release_write()

--- a/lib/ramble/ramble/util/file_util.py
+++ b/lib/ramble/ramble/util/file_util.py
@@ -19,7 +19,7 @@ def get_file_path(path: str, workspace) -> str:
         workspace (ramble.workspace.Workspace): A ramble workspace
 
     Returns:
-        (str): A file path
+        str: A file path
     """
     if not workspace.dry_run or is_dry_run_path(path):
         return path
@@ -49,8 +49,8 @@ def get_newest_experiment_file(base_directory):
         base_directory (str): Directory to search newest file for
 
     Returns:
-        (str): Path to newest file (or None if not found)
-        (int): Timestamp of file in seconds (or None if no file is found)
+        str | None: Path to newest file (or None if not found)
+        int | None: Timestamp of file in seconds (or None if no file is found)
     """
     newest_file = None
     max_mtime = -1.0

--- a/lib/ramble/ramble/util/matrices.py
+++ b/lib/ramble/ramble/util/matrices.py
@@ -19,7 +19,7 @@ def extract_matrices(action, name, in_dict):
         in_dict: The dictionary containing definitions
 
     Returns:
-        list of matrix definitions
+        list[Any]: List of matrix definitions
     """
     matrices = []
 

--- a/lib/ramble/ramble/util/object_utils.py
+++ b/lib/ramble/ramble/util/object_utils.py
@@ -25,7 +25,7 @@ def filter_by_name(glob_patterns: List[str], search_description: bool, obj_type:
         obj_type: type of the Ramble objects to search for
 
     Returns:
-        filtered and sorted list of object names
+        list[str]: filtered and sorted list of object names
     """
     obj_names = set(ramble.repository.all_object_names(obj_type))
     if glob_patterns:

--- a/lib/ramble/ramble/util/path.py
+++ b/lib/ramble/ramble/util/path.py
@@ -81,7 +81,7 @@ def normalize_path_or_url(path):
         path (str): Input path
 
     Returns:
-        (str): Absolute local path or cleaned remote url
+        str: Absolute local path or cleaned remote url
     """
 
     # Remove trailing back-slashes from path

--- a/lib/ramble/ramble/util/yaml_generation.py
+++ b/lib/ramble/ramble/util/yaml_generation.py
@@ -40,7 +40,7 @@ def read_config_file(conf_path: str):
         conf_path (str): Path to input configuration file to read
 
     Returns:
-        (dict): Dictionary representation of the data contained in conf_path
+        dict[str, Any]: Dictionary representation of the data contained in conf_path
     """
     with open(conf_path, encoding="utf-8") as base_conf:
         logger.debug(f"Reading config from {conf_path}")
@@ -59,7 +59,7 @@ def all_config_options(config_data: Dict):
         config_data (dict): A config dictionary representing data read from a YAML file.
 
     Returns:
-        (set): Set containing all detected fully qualified option names
+        set[str]: Set containing all detected fully qualified option names
     """
 
     all_configs = set()
@@ -114,7 +114,7 @@ def get_config_value(config_data: Dict, option_name: str):
         option_name (str): Name of config option to get
 
     Returns:
-        (Any): Value of config option
+        Any: Value of config option
     """
     option_parts = option_name.split(".")
 

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -370,11 +370,7 @@ class VariantSet:
             for_output (bool): If True, returns expanded set for output formatting.
 
         Returns:
-<<<<<<< HEAD
-            (set): Set of expanded variant definitions
-=======
             set[str]: Set of exanded variant definitions
->>>>>>> fd3f15757 (Documentation cleanups and clarifications)
         """
         cache = self._output_set_cache if for_output else self._set_cache
         has_templates = (
@@ -404,17 +400,8 @@ class VariantSet:
             for_output (bool): If True, only include primary variant definitions
                                (e.g., +name or ~name for boolean variants) for display/output.
 
-<<<<<<< HEAD
-        Returns:
-            set: A set consisting of strings with the variant definitions
-=======
-        Args:
-            expander (ramble.expander.Expander): Expander to use when expanding
-                                                 variant definitions
-
         Returns:
             set[str]: A set consisting of strings with the variant definitions
->>>>>>> fd3f15757 (Documentation cleanups and clarifications)
         """
         cache = self._output_set_cache if for_output else self._set_cache
         if cache is not None:

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -83,7 +83,7 @@ class VariantSet:
             verbose: Print verbose
 
         Returns:
-            (str): Representation of this variant set
+            str: Representation of this variant set
         """
         to_print = list(self.default_variants.values())
 
@@ -336,7 +336,7 @@ class VariantSet:
             name: Name of variant to determine value for
 
         Returns:
-            Value of variant if found, otherwise None.
+            Any | None: Value of variant if found, otherwise None.
         """
 
         if name in self.experiment_variants:
@@ -354,7 +354,8 @@ class VariantSet:
             name: Name of the variant to determine version of
 
         Returns:
-            ramble.definitions.versions.ObjectVersion: Version of the variant
+            ramble.definitions.versions.ObjectVersion | None: ObjectVersion of the variant
+            if found, otherwise None.
         """
         if name in self.version_variants:
             return self.version_variants[name].default
@@ -369,7 +370,11 @@ class VariantSet:
             for_output (bool): If True, returns expanded set for output formatting.
 
         Returns:
+<<<<<<< HEAD
             (set): Set of expanded variant definitions
+=======
+            set[str]: Set of exanded variant definitions
+>>>>>>> fd3f15757 (Documentation cleanups and clarifications)
         """
         cache = self._output_set_cache if for_output else self._set_cache
         has_templates = (
@@ -399,8 +404,17 @@ class VariantSet:
             for_output (bool): If True, only include primary variant definitions
                                (e.g., +name or ~name for boolean variants) for display/output.
 
+<<<<<<< HEAD
         Returns:
             set: A set consisting of strings with the variant definitions
+=======
+        Args:
+            expander (ramble.expander.Expander): Expander to use when expanding
+                                                 variant definitions
+
+        Returns:
+            set[str]: A set consisting of strings with the variant definitions
+>>>>>>> fd3f15757 (Documentation cleanups and clarifications)
         """
         cache = self._output_set_cache if for_output else self._set_cache
         if cache is not None:
@@ -532,7 +546,7 @@ class Variant:
         against when clauses.
 
         Returns:
-            tuple: String definitions for this variant
+            tuple[str]: String definitions for this variant
         """
         return self._definitions
 

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -77,9 +77,10 @@ class Workload:
 
         Args:
             n_indent (int): Number of spaces to indent string with
+            verbose (bool): Whether to include verbose information
 
         Returns:
-            (str): Representation of this workload
+            str: Representation of this workload
         """
         attrs = [
             ("Executables", "executables"),
@@ -175,7 +176,7 @@ class Workload:
         """Test if this workload is considered valid
 
         Returns:
-            (bool): True if workload is valid, False otherwise
+            bool: ``True`` if workload is valid, ``False`` otherwise
         """
         if not self.executables:
             return False
@@ -189,7 +190,7 @@ class Workload:
             exec_name (str): Name of executable to find
 
         Returns:
-            (str | None): Name of executable if it exists, None if it is not found
+            str | None: Name of executable if it exists, ``None`` if it is not found
         """
         for executable in self.executables:
             if executable == exec_name:
@@ -203,7 +204,7 @@ class Workload:
             input_name (str): Name of input to find
 
         Returns:
-            (str | None): Name of input if it exists, None if it is not found
+            str | None: Name of input if it exists, ``None`` if it is not found
         """
         for input in self.inputs:
             if input == input_name:
@@ -217,8 +218,8 @@ class Workload:
             var_name (str): Name of variable to find
 
         Returns:
-            (ramble.definitions.variables.Variable | None): Variable instance if it exists, None if
-                it is not found
+            ramble.definitions.variables.Variable | None: Variable instance if it exists,
+            ``None`` if it is not found
         """
         named_vars = []
         for var_list in self.variables.values():
@@ -253,10 +254,11 @@ class WorkloadGroup:
         """String representation of this workload group
 
         Args:
-            n_indent: Number of spaces to indent string with
+            n_indent (int): Number of spaces to indent string with
+            verbose (bool): Whether to include verbose information
 
         Returns:
-            (str): Representation of this workload
+            str: Representation of this workload
 
         """
         indentation = " " * n_indent

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -383,7 +383,8 @@ def get_workspace(args, cmd_name, required=False):
                          is found; if ``False``, just return ``None``
 
     Returns:
-        (Workspace): if there is an arg or active workspace
+        ramble.workspace.Workspace | None: Workspace instance if there is an arg or active
+        workspace, ``None`` if no workspace is found and ``required`` is ``False``
     """
 
     logger.debug("In get_workspace()")
@@ -2289,7 +2290,7 @@ ramble:
         """Construct a list of all modifiers in this workspace, and their associated scope.
 
         Returns:
-            (list): List of tuples, of the form (scope, modifier_definition)
+            list[tuple]: List of tuples, of the form (scope, modifier_definition)
         """
         base_section = self._get_scope_section("workspace")
         ws_mods = base_section.get(namespace.modifiers, [])
@@ -2368,7 +2369,7 @@ ramble:
             dry_run: Whether to print the config instead of editing it, or to edit it directly.
 
         Returns:
-            (int) Number of modifiers removed
+            int: Number of modifiers removed
         """
         mod_list = self.index_modifiers()
         to_remove = []
@@ -2449,7 +2450,7 @@ ramble:
             dry_run: Whether to print the config instead of editing it, or to edit it directly.
 
         Returns:
-            (int) Number of modifiers added to workspace
+            int: Number of modifiers added to workspace
         """
         on_exec_list = None
         if on_executable is not None:

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3262,7 +3262,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 "any object in an experiment's hierarchy.\n"
                 "Hashes are compared to ensure experiments that are set up match the expected "
                 "contents from these sources.\n"
-                "Hashes can be overwritten if you are sure this is safe, and what you want."
+                "Hashes can be overwritten if you are sure this is safe, and what you want. "
                 "To overwrite the experiment hash, use the global --overwrite-inventories option."
             )
 


### PR DESCRIPTION
Documentation and Tutorial fixes:

- Updates existing tutorials to fix problems when using current ramble, spack, and spack packages
- Adds a new `workspace manage experiments` tutorial
- Lots of documentation fixes especially regarding Return values and specifying they're Return Types
- Minor config change to allow sphinx `--fail-on-warning` to pass

There's still a lot of work that could be done to standardize formatting for documentation, but this PR addresses documentation that already exists in the expected sphinx format to be more compliant and explicit.