### PR TITLE
add support for include in templates

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/template.py
+++ b/lib/ramble/ramble/test/end_to_end/template.py
@@ -175,3 +175,81 @@ ramble:
     assert os.path.isfile(
         os.path.join(ws.experiment_dir, f"template/test_template/test/{template_src_name}")
     )
+
+
+def test_template_inclusion(make_workspace_from_config):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: mpirun -n {n_ranks}
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: 1
+  applications:
+    template:
+      workloads:
+        test_template:
+          experiments:
+            test:
+              variables:
+                n_nodes: 1
+                hello_name: inclusion_test
+"""
+    ws, ws_name = make_workspace_from_config(test_config)
+
+    # 1. Create a child workspace template
+    child_path = os.path.join(ws.config_dir, "child_tpl.tpl")
+    with open(child_path, "w", encoding="utf-8") as f:
+        f.write("Child content: hello {hello_name}\n")
+
+    # 2. Create a parent workspace template that includes the child workspace template
+    # and the object template 'bar'
+    parent_path = os.path.join(ws.config_dir, "parent_tpl.tpl")
+    with open(parent_path, "w", encoding="utf-8") as f:
+        f.write("Parent header\n")
+        f.write("include({child_tpl})\n")
+        f.write("include({bar})\n")
+        f.write("Parent footer\n")
+
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+
+    run_dir = os.path.join(ws.experiment_dir, "template/test_template/test/")
+
+    # Verify child_tpl rendered output
+    rendered_child_path = os.path.join(run_dir, "child_tpl")
+    assert os.path.isfile(rendered_child_path)
+    with open(rendered_child_path, encoding="utf-8") as f:
+        child_content = f.read()
+        assert child_content == "Child content: hello inclusion_test\n"
+
+    # Verify parent_tpl rendered output
+    rendered_parent_path = os.path.join(run_dir, "parent_tpl")
+    assert os.path.isfile(rendered_parent_path)
+    with open(rendered_parent_path, encoding="utf-8") as f:
+        parent_content = f.read()
+        # It should contain parent header
+        assert "Parent header\n" in parent_content
+        # It should expand child_tpl in-place (with variables expanded in child context)
+        assert "Child content: hello inclusion_test\n" in parent_content
+        # It should expand object template 'bar' in-place (with bar's extra_vars/func expanded)
+        assert "foobar\n" in parent_content  # dynamic_var1 from bar's extra_vars
+        # dynamic_hello_world from bar's extra_vars_func
+        assert "hello inclusion_test\n" in parent_content
+        # It should contain parent footer
+        assert "Parent footer\n" in parent_content
+
+    # 3. Test circular inclusion raises ApplicationError
+    circ_a_path = os.path.join(ws.config_dir, "circ_a.tpl")
+    circ_b_path = os.path.join(ws.config_dir, "circ_b.tpl")
+    with open(circ_a_path, "w", encoding="utf-8") as f:
+        f.write("include({circ_b})\n")
+    with open(circ_b_path, "w", encoding="utf-8") as f:
+        f.write("include({circ_a})\n")
+
+    # Re-read workspace to pick up new templates
+    ws._re_read()
+
+    with pytest.raises(
+        ApplicationError,
+        match="Circular template inclusion detected: circ_a -> circ_b -> circ_a",
+    ):
+        workspace("setup", "--dry-run", global_args=["-w", ws_name])

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -2219,7 +2219,8 @@ ramble:
 
     def all_templates(self):
         """Iterator over each template in the workspace"""
-        yield from self._templates.items()
+        yield from sorted(self._templates.items())
+
 
     def all_auxiliary_software_files(self):
         """Iterator over each auxiliary software file"""

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -2221,7 +2221,6 @@ ramble:
         """Iterator over each template in the workspace"""
         yield from sorted(self._templates.items())
 
-
     def all_auxiliary_software_files(self):
         """Iterator over each auxiliary software file"""
         yield from self._auxiliary_software_files.items()

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3010,15 +3010,15 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             for mod in self._modifier_instances:
                 exec_vars.update(mod.modded_variables(self, exec_vars))
 
-            for template_name, template_conf in workspace.all_templates():
+            for template_name, _ in workspace.all_templates():
                 expand_path = os.path.join(experiment_run_dir, template_name)
                 logger.msg(
                     f"Writing template {template_name} to {expand_path}"
                 )
                 fs.mkdirp(os.path.dirname(expand_path))
 
-                rendered_content = self.expander.expand_var(
-                    template_conf["contents"], extra_vars=exec_vars
+                rendered_content = self._get_rendered_template_content(
+                    template_name, exec_vars, rendering_stack=[]
                 )
 
                 with open(expand_path, "w+", encoding="utf-8") as f:
@@ -4498,7 +4498,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 expander.expand_var(path), local_replacements=replacements
             )
 
-        def _get_template_config(obj, tpl_config, obj_type):
+        def _get_template_config(obj, name, tpl_config, obj_type):
             # Resolve the source path
             src_path_config = _expand_path(tpl_config["src_path"])
             if not src_path_config.endswith(tpl_ext):
@@ -4543,7 +4543,12 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             if not os.path.isabs(dest_path):
                 dest_path = os.path.join(run_dir, dest_path)
 
-            return {**tpl_config, "src_path": src_path, "dest_path": dest_path}
+            return {
+                "name": name,
+                **tpl_config,
+                "src_path": src_path,
+                "dest_path": dest_path,
+            }
 
         for obj_type, obj in self.objects():
             obj_tpls = []
@@ -4554,28 +4559,85 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     continue
 
                 obj_tpls.extend(
-                    _get_template_config(obj, tpl_conf, obj_type=obj_type)
-                    for tpl_conf in tpl.values()
+                    _get_template_config(
+                        obj, name, tpl_conf, obj_type=obj_type
+                    )
+                    for name, tpl_conf in tpl.items()
                 )
             if obj_tpls:
                 yield obj, obj_tpls
 
+    def _get_rendered_template_content(
+        self, template_name, extra_vars_origin, rendering_stack=None
+    ):
+        """Retrieve and fully render template content, expanding includes in-place recursively"""
+        if rendering_stack is None:
+            rendering_stack = []
+
+        if template_name in rendering_stack:
+            cycle = " -> ".join(rendering_stack + [template_name])
+            raise ApplicationError(
+                f"Circular template inclusion detected: {cycle}"
+            )
+
+        rendering_stack.append(template_name)
+        try:
+            content = None
+            extra_vars = extra_vars_origin.copy()
+
+            if template_name in self.workspace._templates:
+                content = self.workspace._templates[template_name]["contents"]
+            else:
+                found = False
+                for obj, tpl_configs in self._object_templates():
+                    for tpl_config in tpl_configs:
+                        if tpl_config["name"] == template_name:
+                            src_path = tpl_config["src_path"]
+                            content = self.workspace.read_file_content(
+                                src_path
+                            )
+                            extra_vars_dict = tpl_config.get("extra_vars")
+                            if extra_vars_dict is not None:
+                                extra_vars.update(extra_vars_dict)
+                            extra_vars_func_name = tpl_config.get(
+                                "extra_vars_func_name"
+                            )
+                            if extra_vars_func_name is not None:
+                                extra_vars_func = getattr(
+                                    obj, extra_vars_func_name
+                                )
+                                extra_vars.update(extra_vars_func())
+                            found = True
+                            break
+                    if found:
+                        break
+
+            if content is None:
+                raise ApplicationError(
+                    f"Template '{template_name}' not found for inclusion."
+                )
+
+            def replace_include(match):
+                child_tpl_name = match.group(1)
+                return self._get_rendered_template_content(
+                    child_tpl_name, extra_vars, rendering_stack
+                )
+
+            processed_content = re.sub(
+                r"include\(\s*\{([^}]+)\}\s*\)", replace_include, content
+            )
+
+            return self.expander.expand_var(
+                processed_content, extra_vars=extra_vars
+            )
+        finally:
+            rendering_stack.pop()
+
     def _render_object_templates(self, extra_vars_origin):
-        workspace = self.workspace
-        for obj, tpl_configs in self._object_templates():
+        for _, tpl_configs in self._object_templates():
             for tpl_config in tpl_configs:
-                extra_vars = extra_vars_origin.copy()
-                src_path = tpl_config["src_path"]
-                content = workspace.read_file_content(src_path)
-                extra_vars_dict = tpl_config.get("extra_vars")
-                if extra_vars_dict is not None:
-                    extra_vars.update(extra_vars_dict)
-                extra_vars_func_name = tpl_config.get("extra_vars_func_name")
-                if extra_vars_func_name is not None:
-                    extra_vars_func = getattr(obj, extra_vars_func_name)
-                    extra_vars.update(extra_vars_func())
-                rendered = self.expander.expand_var(
-                    content, extra_vars=extra_vars
+                rendered = self._get_rendered_template_content(
+                    tpl_config["name"], extra_vars_origin, rendering_stack=[]
                 )
                 out_path = tpl_config["dest_path"]
                 perm = tpl_config.get("content_perm", _DEFAULT_CONTENT_PERM)

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -4487,6 +4487,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def _object_templates(self):
         """Return templates defined from different objects associated with the app_inst"""
+        if hasattr(self, "_cached_object_templates"):
+            return self._cached_object_templates
+
         workspace = self.workspace
         run_dir = self.expander.experiment_run_dir
         replacements = workspace.workspace_paths()
@@ -4550,6 +4553,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 "dest_path": dest_path,
             }
 
+        cached_templates = []
         for obj_type, obj in self.objects():
             obj_tpls = []
             for when_set, tpl in obj.templates.items():
@@ -4565,7 +4569,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     for name, tpl_conf in tpl.items()
                 )
             if obj_tpls:
-                yield obj, obj_tpls
+                cached_templates.append((obj, obj_tpls))
+
+        self._cached_object_templates = cached_templates
+        return self._cached_object_templates
 
     def _get_rendered_template_content(
         self, template_name, extra_vars_origin, rendering_stack=None


### PR DESCRIPTION
```
#!/bin/bash
# This is a template execution script for
# running the execute pipeline.

{workflow_banner}

cd "{experiment_run_dir}"

echo "In-place inclusion demo starting:"
include({child_tpl})
include({another_child_tpl})
echo "In-place inclusion demo finished."

{command}
```
Gives:
```
...
echo "In-place inclusion demo starting:"
echo "I am the child workspace template."
echo "processes_per_node is 1"

echo "I am another child workspace template."
echo "n_nodes is 1"

echo "In-place inclusion demo finished."
...
```
