### PR TITLE
make it so unit tests dont fail on style by default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -52,6 +52,12 @@ def pytest_addoption(parser):
         help='runs only "fast" unit tests, instead of the whole suite',
     )
     group.addoption(
+        "--fail-on-style",
+        action="store_true",
+        default=False,
+        help="fail unit tests if style is bad in the repository",
+    )
+    group.addoption(
         "--slow",
         action="store_true",
         default=False,

--- a/lib/ramble/ramble/cmd/style.py
+++ b/lib/ramble/ramble/cmd/style.py
@@ -507,9 +507,22 @@ def run_black(black_cmd, file_list, args):
                 file=sys.stderr,
             )
 
+    help_out = black_cmd("-h", output=str, error=str)
+    supported_versions = set()
+    help_match = re.search(r"--target-version\s+\[([^\]]+)\]", help_out)
+    if help_match:
+        supported_versions = set(help_match.group(1).split("|"))
+
+    desired_versions = ["py36", "py37", "py38", "py39", "py310", "py311", "py312", "py313"]
+    target_args = []
+    for ver in desired_versions:
+        if ver in supported_versions:
+            target_args.extend(["--target-version", ver])
+
     common_args = ("--config", os.path.join(ramble.paths.prefix, "pyproject.toml"))
     if not args.fix:
         common_args += ("--check", "--diff")
+    common_args += tuple(target_args)
     common_args += tuple(get_tool_args(args, "black"))
     primary_files, obj_files = _split_file_list(file_list, args)
     output = ""

--- a/lib/ramble/ramble/cmd/style.py
+++ b/lib/ramble/ramble/cmd/style.py
@@ -569,15 +569,21 @@ def run_isort(isort_cmd, file_list, args):
 
 @tool("mypy")
 def run_mypy(mypy_cmd, file_list, args):
-    del file_list
     if args.repo_path is not None:
         print("Skipping mypy for external repository.")
         return 0
-    print_tool_header("mypy", [])
+    print_tool_header("mypy", file_list)
 
     config_file = os.path.join(ramble.paths.prefix, "pyproject.toml")
-    mypy_args = ("--config-file", config_file)
-    mypy_args += tuple(get_tool_args(args, "mypy"))
+    mypy_args = ["--config-file", config_file]
+    mypy_args.extend(get_tool_args(args, "mypy"))
+
+    if file_list:
+        mypy_files = [f for f in file_list if f.startswith("lib/ramble/ramble/")]
+        if not mypy_files:
+            print_tool_result("mypy", 0)
+            return 0
+        mypy_args.extend(mypy_files)
 
     output = mypy_cmd(*mypy_args, fail_on_error=False, output=str, error=str)
     returncode = mypy_cmd.returncode

--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -62,6 +62,12 @@ def setup_parser(subparser):
         default=False,
         help="run only performance tests",
     )
+    subparser.add_argument(
+        "--fail-on-style",
+        action="store_true",
+        default=False,
+        help="fail unit tests if style is bad in the repository",
+    )
     speed = subparser.add_mutually_exclusive_group()
     speed.add_argument(
         "--fast",
@@ -211,6 +217,8 @@ def add_back_pytest_args(args, unknown_args):
         result += ["--fast"]
     if args.slow:
         result += ["--slow"]
+    if args.fail_on_style:
+        result += ["--fail-on-style"]
     result += unknown_args or []
     result += args.pytest_args or []
     if args.expression:

--- a/lib/ramble/ramble/test/cmd/style.py
+++ b/lib/ramble/ramble/test/cmd/style.py
@@ -15,11 +15,23 @@ from ramble.cmd import style
 style_cmd = main.RambleCommand("style")
 
 
+def _get_changed_files_with_fallback():
+    files = []
+    for base in [None, "origin/develop", "origin/main"]:
+        try:
+            files = style.changed_files(base=base, all_files=False)
+            if files:
+                break
+        except Exception:
+            pass
+    return files
+
+
 @pytest.mark.parametrize("tool", style.tool_names)
 def test_style(tool, request):
     fail_on_style = request.config.getoption("--fail-on-style")
     if fail_on_style:
-        files = style.changed_files(all_files=False)
+        files = _get_changed_files_with_fallback()
         if files:
             out = style_cmd("--tool", tool, *files)
             assert f"{tool} checks were clean" in out
@@ -180,3 +192,52 @@ def test_style_external_repo(tmpdir):
     out = style_cmd("--repo-path", str(tmpdir), "-a", "-t", "flake8")
     assert "style checks were clean" in out
     assert "applications/test_app/application.py" in out
+
+
+def test_black_target_version_parsing(capsys):
+    class MockExecutable:
+        def __init__(self):
+            self.args_received = []
+            self.returncode = 0
+
+        def __call__(self, *args, **kwargs):
+            if "-h" in args:
+                return "  -t, --target-version [py36|py37|py38|py39|py310|py311|py312]"
+            self.args_received.extend(args)
+            return ""
+
+    mock_black = MockExecutable()
+
+    class MockArgs:
+        fix = False
+        root_relative = False
+        repo_path = None
+
+    args = MockArgs()
+
+    style.run_black(mock_black, ["lib/ramble/ramble/cmd/style.py"], args)
+
+    expected_versions = ["py36", "py37", "py38", "py39", "py310", "py311", "py312"]
+    for ver in expected_versions:
+        assert "--target-version" in mock_black.args_received
+        assert ver in mock_black.args_received
+    assert "py313" not in mock_black.args_received
+
+
+def test_changed_files_fallback(monkeypatch):
+    calls = []
+
+    def mock_changed_files(base, all_files):
+        calls.append(base)
+        if base == "origin/main":
+            return ["file1.py"]
+        elif base == "origin/develop":
+            return []
+        raise Exception("Mock error simulating missing branch")
+
+    monkeypatch.setattr(style, "changed_files", mock_changed_files)
+
+    files = _get_changed_files_with_fallback()
+    assert files == ["file1.py"]
+    # Check that it tried None, origin/develop, and origin/main in order
+    assert calls == [None, "origin/develop", "origin/main"]

--- a/lib/ramble/ramble/test/cmd/style.py
+++ b/lib/ramble/ramble/test/cmd/style.py
@@ -9,16 +9,23 @@
 
 import pytest
 
-from ramble import main, paths
+from ramble import main
 from ramble.cmd import style
 
 style_cmd = main.RambleCommand("style")
 
 
 @pytest.mark.parametrize("tool", style.tool_names)
-def test_style(tool):
-    out = style_cmd("--tool", tool, __file__)
-    assert f"{tool} checks were clean" in out
+def test_style(tool, request):
+    fail_on_style = request.config.getoption("--fail-on-style")
+    if fail_on_style:
+        files = style.changed_files(all_files=False)
+        if files:
+            out = style_cmd("--tool", tool, *files)
+            assert f"{tool} checks were clean" in out
+    else:
+        out = style_cmd("--tool", tool, __file__)
+        assert f"{tool} checks were clean" in out
 
 
 @pytest.mark.parametrize(
@@ -86,6 +93,8 @@ def test_style_invalid_repo(tmpdir):
 
 
 def test_style_valid_repo():
+    from ramble import paths
+
     builtin_mock_repo = paths.mock_builtin_path
     out = style_cmd("--repo-path", builtin_mock_repo)
     assert "style checks were clean" in out

--- a/pyproject_objects.toml
+++ b/pyproject_objects.toml
@@ -2,7 +2,7 @@
 
 [tool.black]
 line-length = 79
-target-version = ["py36", "py37", "py38", "py39", "py310"]
+target-version = ["py36", "py37", "py38", "py39", "py310", "py311", "py312"]
 include = '''
     \.pyi?$
 '''

--- a/pyproject_objects.toml
+++ b/pyproject_objects.toml
@@ -2,7 +2,7 @@
 
 [tool.black]
 line-length = 79
-target-version = ["py36", "py37", "py38", "py39", "py310", "py311", "py312"]
+target-version = ["py36", "py37", "py38", "py39", "py310"]
 include = '''
     \.pyi?$
 '''

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -647,7 +647,7 @@ _ramble_style() {
 _ramble_unit_test() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path --perf --fast --slow -l --list -L --list-long -N --list-names -s -k --showlocals"
+        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path --perf --fail-on-style --fast --slow -l --list -L --list-long -N --list-names -s -k --showlocals"
     else
         _unit_tests
     fi


### PR DESCRIPTION
right now `ramble unit-test` calls style, which can cause the PR correctness test to fail when they are "correct" just poorly styled. I'm hoping to de-couple 