### PR TITLE
Only output boolean variants once

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -32,6 +32,7 @@ import ramble.workspace.shell
 from ramble import ramble_version
 from ramble.cmd.common import arguments
 from ramble.namespace import namespace
+from ramble.util.format import when_order
 from ramble.util.logger import logger
 
 import spack.util.environment
@@ -1028,9 +1029,11 @@ def workspace_info(args):
                         variant_set = set()
                         for _, obj in app_inst.objects():
                             variant_set = variant_set.union(
-                                obj.experiment_variants().as_set(expander=app_inst.expander)
+                                obj.experiment_variants().as_set(
+                                    expander=app_inst.expander, for_output=True
+                                )
                             )
-                        for variant in variant_set:
+                        for variant in sorted(variant_set, key=when_order):
                             color.cprint(f"          - {variant}")
 
                     if args.executables:

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -13,6 +13,7 @@ from ramble.namespace import namespace
 from ramble.software_info import SoftwareInfo
 from ramble.util import json_util
 from ramble.util.file_util import get_newest_experiment_file
+from ramble.util.format import when_order
 from ramble.util.logger import logger
 
 
@@ -145,7 +146,9 @@ class ExperimentResult:
             if var not in app_inst.keywords.keys or not app_inst.keywords.is_key_level(var):
                 self.variables[var] = app_inst.expander.expand_var(val)
 
-        self.variants = sorted(app_inst.experiment_variants().as_set())
+        self.variants = sorted(
+            app_inst.experiment_variants().as_set(for_output=True), key=when_order
+        )
 
         self.object_definitions = app_inst.object_inventory()
 

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -13,6 +13,7 @@ import pytest
 import ramble.variants
 import ramble.workspace
 from ramble.main import RambleCommand
+from ramble.util.format import when_order
 
 pytestmark = pytest.mark.usefixtures(
     "mutable_config",
@@ -614,3 +615,32 @@ def test_workload_group_variant(workspace_name):
 
         assert "workload_group=test_wl_group" in info_out
         assert "workload_group=all_workloads" in info_out
+
+
+def test_boolean_variant_output_formatting():
+    v_set = ramble.variants.VariantSet()
+    v_set.default_variant("bool_var", default=True, values=[True, False])
+    v_set.default_variant("false_var", default=False, values=[True, False])
+    v_set.default_variant("str_var", default="foo")
+
+    # Evaluation set contains all condition forms for when clause matching
+    eval_set = v_set.as_set()
+    assert "+bool_var" in eval_set
+    assert "bool_var=True" in eval_set
+    assert "bool_var=true" in eval_set
+    assert "~false_var" in eval_set
+    assert "false_var=False" in eval_set
+    assert "false_var=false" in eval_set
+
+    # Output set contains only + or ~ format for booleans
+    output_set = v_set.as_set(for_output=True)
+    assert "+bool_var" in output_set
+    assert "bool_var=True" not in output_set
+    assert "bool_var=true" not in output_set
+    assert "~false_var" in output_set
+    assert "false_var=False" not in output_set
+    assert "false_var=false" not in output_set
+    assert "str_var=foo" in output_set
+
+    sorted_output = sorted(output_set, key=when_order)
+    assert sorted_output == ["str_var=foo", "+bool_var", "~false_var"]

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -62,11 +62,13 @@ class VariantSet:
         self._set_cache = None
         self._output_set_cache = None
         self._has_template_variants = False
+        self._has_output_template_variants = False
 
     def _invalidate_cache(self):
         self._set_cache = None
         self._output_set_cache = None
         self._has_template_variants = False
+        self._has_output_template_variants = False
 
     def __str__(self):
         if not hasattr(self, "_str_indent"):
@@ -370,8 +372,11 @@ class VariantSet:
             (set): Set of expanded variant definitions
         """
         cache = self._output_set_cache if for_output else self._set_cache
+        has_templates = (
+            self._has_output_template_variants if for_output else self._has_template_variants
+        )
 
-        if expander is None or not self._has_template_variants:
+        if expander is None or not has_templates:
             return cache
 
         expanded_set = set()
@@ -460,7 +465,10 @@ class VariantSet:
             self._set_cache = out_set
 
         if any("{" in v for v in out_set):
-            self._has_template_variants = True
+            if for_output:
+                self._has_output_template_variants = True
+            else:
+                self._has_template_variants = True
 
         return self._expanded_set(expander, for_output=for_output)
 

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -60,10 +60,12 @@ class VariantSet:
         self.experiment_variants = {}
         self.version_variants = {}
         self._set_cache = None
+        self._output_set_cache = None
         self._has_template_variants = False
 
     def _invalidate_cache(self):
         self._set_cache = None
+        self._output_set_cache = None
         self._has_template_variants = False
 
     def __str__(self):
@@ -357,43 +359,56 @@ class VariantSet:
 
         return None
 
-    def _expanded_set(self, expander: Optional[Expander] = None) -> set:
+    def _expanded_set(self, expander: Optional[Expander] = None, for_output: bool = False) -> set:
         """Return an expanded version of the cached set in this variant set.
 
         Args:
             expander (ramble.expander.Expander): Expander to use for expanding this set
+            for_output (bool): If True, returns expanded set for output formatting.
 
         Returns:
-            (set): Set of exanded variant definitions
+            (set): Set of expanded variant definitions
         """
+        cache = self._output_set_cache if for_output else self._set_cache
 
         if expander is None or not self._has_template_variants:
-            return self._set_cache
+            return cache
 
         expanded_set = set()
-        for variant in self._set_cache:
+        for variant in cache:
             if "{" in variant:
                 expanded_set.add(expander.expand_var(variant))
             else:
                 expanded_set.add(variant)
         return expanded_set
 
-    def as_set(self, expander: Optional[Expander] = None) -> set:
+    def as_set(self, expander: Optional[Expander] = None, for_output: bool = False) -> set:
         """Construct a set of definitions for this variant set
 
         The set of variant definitions will be used to determine if a when
-        clause is valid or not.
+        clause is valid or not, or formatted for output.
+
+        Args:
+            expander (ramble.expander.Expander): Expander to use when expanding
+                                                 variant definitions
+            for_output (bool): If True, only include primary variant definitions
+                               (e.g., +name or ~name for boolean variants) for display/output.
 
         Returns:
             set: A set consisting of strings with the variant definitions
-            expander (ramble.expander.Expander): Expander to use when expanding
-                                                 variant definitions
         """
-        if self._set_cache is not None:
-            return self._expanded_set(expander)
+        cache = self._output_set_cache if for_output else self._set_cache
+        if cache is not None:
+            return self._expanded_set(expander, for_output=for_output)
 
         defined_variants = set()
         out_set = set()
+
+        def _add_variant(var):
+            if for_output:
+                out_set.add(var.as_definition())
+            else:
+                out_set.update(var.as_definitions())
 
         for name, variant in self.experiment_variants.items():
             if name in self.default_variants or name in reserved_variants:
@@ -422,26 +437,32 @@ class VariantSet:
                                 f"   Valid values include: {values}"
                             )
 
-                out_set.update(variant.as_definitions())
+                _add_variant(variant)
                 defined_variants.add(name)
 
         for name, variant in self.default_variants.items():
             if name not in defined_variants:
-                out_set.update(variant.as_definitions())
+                _add_variant(variant)
                 defined_variants.add(name)
 
         for variant_list in self.multi_value_variants.values():
             for variant in variant_list:
-                out_set.update(variant.as_definitions())
+                _add_variant(variant)
 
         # Version variants are included as strings in the set for completeness, but should be
         # checked using the stored ObjectVersion class instead of a string comparison.
         for variant in self.version_variants.values():
-            out_set.update(variant.as_definitions())
+            _add_variant(variant)
 
-        self._set_cache = out_set
-        self._has_template_variants = any("{" in v for v in out_set)
-        return self._expanded_set(expander)
+        if for_output:
+            self._output_set_cache = out_set
+        else:
+            self._set_cache = out_set
+
+        if any("{" in v for v in out_set):
+            self._has_template_variants = True
+
+        return self._expanded_set(expander, for_output=for_output)
 
 
 class Variant:

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -442,9 +442,13 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     found = True
 
         if not found:
+            sorted_variants = sorted(
+                self.experiment_variants().as_set(for_output=True),
+                key=when_order,
+            )
             logger.die(
                 "No workloads satisfy the current `when` conditions: \n"
-                f"  {self.experiment_variants().as_set(for_output=True)}"
+                f"  {sorted_variants}"
             )
 
     def _set_package_manager(self):

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -63,6 +63,7 @@ from ramble.language.shared_language import (
 )
 from ramble.util import cleaner, conversions, json_util
 from ramble.util.foms import FomType, SummaryFoms, get_literal_from_regex
+from ramble.util.format import when_order
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 from ramble.util.output_capture import output_mapper
@@ -443,7 +444,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if not found:
             logger.die(
                 "No workloads satisfy the current `when` conditions: \n"
-                f"  {self.experiment_variants().as_set()}"
+                f"  {self.experiment_variants().as_set(for_output=True)}"
             )
 
     def _set_package_manager(self):
@@ -3087,10 +3088,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         for _, obj in self.objects():
             variant_definitions = variant_definitions.union(
-                obj.experiment_variants(app_inst=self).as_set()
+                obj.experiment_variants(app_inst=self).as_set(for_output=True)
             )
 
-        return sorted(variant_definitions)
+        return sorted(variant_definitions, key=when_order)
 
     def _purge_inventory(self):
         self.hash_inventory = {

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -18,6 +18,7 @@ import llnl.util.filesystem as fs
 from ramble.error import ApplicationError
 from ramble.pkgmankit import *
 from ramble.util.executable import PrefixedExecutable, which
+from ramble.util.format import when_order
 from ramble.util.hashing import hash_string
 from ramble.util.logger import logger
 from ramble.util.shell_utils import source_str
@@ -158,12 +159,16 @@ class Pip(PackageManagerBase):
                     )
                     and pkg not in installed_pkgs
                 ):
+                    sorted_vars = sorted(
+                        self.experiment_variants().as_set(for_output=True),
+                        key=when_order,
+                    )
                     logger.die(
                         f"Package {pkg} is not installed "
                         f"in environment {env_context}, but is "
                         f"required by the {app_inst.name} application "
                         "definition\n",
-                        f"{self.experiment_variants().as_set(for_output=True)}\n",
+                        f"{sorted_vars}\n",
                         f"{conf['when']}",
                     )
 

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -163,7 +163,7 @@ class Pip(PackageManagerBase):
                         f"in environment {env_context}, but is "
                         f"required by the {app_inst.name} application "
                         "definition\n",
-                        f"{self.experiment_variants().as_set()}\n",
+                        f"{self.experiment_variants().as_set(for_output=True)}\n",
                         f"{conf['when']}",
                     )
 


### PR DESCRIPTION
Updates VariantSet to only output boolean variants in a single format when printing or saving to results. Also applies `when_order` function more broadly to ensure consistency of variant sorting in output.