### PR TITLE
Fix up some issues discovered by `ruff`

### DIFF
--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -898,7 +898,7 @@ class RepoPath:
 
     def in_path(self, maybe_obj_path):
         """Whether the path belongs to any of the repos."""
-        return any(os.path.commonprefix([maybe_obj_path, r.root]) == r.root for r in self.repos)
+        return any(os.path.commonpath([maybe_obj_path, r.root]) == r.root for r in self.repos)
 
     # TODO: DWJ - Maybe we don't need this? Are we going to have virtual
     #             objects

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -898,7 +898,15 @@ class RepoPath:
 
     def in_path(self, maybe_obj_path):
         """Whether the path belongs to any of the repos."""
-        return any(os.path.commonpath([maybe_obj_path, r.root]) == r.root for r in self.repos)
+        if not maybe_obj_path:
+            return False
+
+        abs_obj_path = os.path.abspath(maybe_obj_path)
+        for r in self.repos:
+            abs_root = os.path.abspath(r.root)
+            if os.path.commonpath([abs_obj_path, abs_root]) == abs_root:
+                return True
+        return False
 
     # TODO: DWJ - Maybe we don't need this? Are we going to have virtual
     #             objects

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -192,7 +192,7 @@ def add_input_file(app_inst, input_num=1):
 def add_compiler(app_inst, spec_num=1):
     spec_name = f"Compiler{spec_num}"
     spec_pkg_spec = f"compiler_base@{spec_num}.0 +var1 ~var2"
-    spec_compiler_spec = "compiler1_base@{spec_num}"
+    spec_compiler_spec = f"compiler1_base@{spec_num}"
 
     spec_defs = {}
     spec_defs[spec_name] = {"pkg_spec": spec_pkg_spec, "compiler_spec": spec_compiler_spec}
@@ -201,7 +201,7 @@ def add_compiler(app_inst, spec_num=1):
 
     spec_name = f"OtherCompiler{spec_num}"
     spec_pkg_spec = f"compiler_base@{spec_num}.1 +var1 ~var2 target=x86_64"
-    spec_compiler_spec = "compiler2_base@{spec_num}"
+    spec_compiler_spec = f"compiler2_base@{spec_num}"
 
     spec_defs[spec_name] = {"pkg_spec": spec_pkg_spec, "compiler_spec": spec_compiler_spec}
 

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -100,7 +100,7 @@ class Pip(PackageManagerBase):
 
         cache_tupl = ("pip-env", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug("{cache_tupl} already in cache")
+            logger.debug(f"{cache_tupl} already in cache")
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -138,7 +138,7 @@ class Pip(PackageManagerBase):
 
         cache_tupl = ("pip-install", env_path)
         if workspace.check_cache(cache_tupl):
-            logger.debug("{cache_tupl} already in cache")
+            logger.debug(f"{cache_tupl} already in cache")
             return
         else:
             workspace.add_to_cache(cache_tupl)


### PR DESCRIPTION
* Use commonpath instead of commonprefix, as the latter may give false positive: https://docs.astral.sh/ruff/rules/os-path-commonprefix/
* Fix up a couple strings that should've been f-strings

The ruff rulesets that lead to these discoveries are not included in our config yet, as they give too many false positives.