### PR TITLE
Update compiler loading for spack to use `--first`

### DIFF
--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -963,7 +963,7 @@ class SpackRunner(CommandRunner):
         self._load_compiler_shell(spec, shell_flag, regex)
 
     def _load_compiler_shell(self, spec, shell_flag, regex):
-        args = ["load", shell_flag, spec]
+        args = ["load", "--first", shell_flag, spec]
 
         load_cmds = self.execute(self.spack, args, return_output=True)
 


### PR DESCRIPTION
This merge updates the spack logic for loading a compiler to use the `--first` flag, instead of allowing it to error if multiple specs match the requested one.