### PR TITLE
Allow namespaced specs

### DIFF
--- a/lib/ramble/docs/dev_guides/shared/repository_create.rst
+++ b/lib/ramble/docs/dev_guides/shared/repository_create.rst
@@ -104,7 +104,8 @@ Common object type abbreviations include:
 * ``sys`` or ``system`` for systems
 * ``plat`` or ``platform`` for platforms
 
+Base objects can be referenced with the ``base_<type_abbrev>`` prefix.
+
 These namespaced specs can be used in CLI commands (e.g., ``ramble info <spec>``,
 ``ramble edit <spec>``, ``ramble create <spec>``) and in workspace configuration files
 (``ramble.yaml``) under the ``applications:`` and ``environments:`` sections.
-

--- a/lib/ramble/docs/dev_guides/shared/repository_create.rst
+++ b/lib/ramble/docs/dev_guides/shared/repository_create.rst
@@ -82,3 +82,29 @@ when multiple exist with the same name. Each repository has a namespace, and
 these namespaces can be used to refer to specific instances of each object
 definition.
 
+Referencing Objects with Namespaces
+-----------------------------------
+
+When multiple repositories contain objects with the same name, or when you want
+to be explicit about which repository an object comes from, you can use fully-qualified
+namespaced specs.
+
+Namespaced specs take the form:
+
+* ``<namespace>.<object_name>`` (e.g., ``tutorial-repo.hostname``, ``builtin.wrf``)
+* ``<namespace>.<type_abbrev>.<object_name>`` (e.g., ``tutorial-repo.app.hostname``, ``builtin.mod.my_modifier``)
+* ``<namespace>.<type_abbrev>.<object_name>@<version>`` (e.g., ``builtin.app.wrf@4.2``, ``builtin.app.wrf@{version}``)
+
+Common object type abbreviations include:
+
+* ``app`` or ``application`` for applications
+* ``mod`` or ``modifier`` for modifiers
+* ``pkg_man`` or ``package_manager`` for package managers
+* ``wm`` or ``workflow_manager`` for workflow managers
+* ``sys`` or ``system`` for systems
+* ``plat`` or ``platform`` for platforms
+
+These namespaced specs can be used in CLI commands (e.g., ``ramble info <spec>``,
+``ramble edit <spec>``, ``ramble create <spec>``) and in workspace configuration files
+(``ramble.yaml``) under the ``applications:`` and ``environments:`` sections.
+

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -93,7 +93,9 @@ In the above example, the experiment name would be: ``test_1_1`` when it is crea
 
 **NOTE:** Each experiment has a namespace that follows this pattern:
 ``application.workload.experiment``. Every experiment needs a unique namespace,
-or ramble will throw an error.
+or ramble will throw an error. Application entries can be specified with short names
+(e.g., ``hostname``), fully qualified namespaced specs (e.g., ``builtin.app.hostname``),
+or with version suffixes (e.g., ``builtin.app.wrf@{version}`` or ``wrf@4.2``).
 
 .. _variable-dictionaries:
 

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -13,6 +13,7 @@ import textwrap
 from llnl.util.tty.colify import colified
 
 import ramble.repository
+import ramble.spec
 import ramble.util.colors as color
 from ramble.cmd.common import arguments
 from ramble.definitions.variables import Variable
@@ -78,7 +79,13 @@ def _map_attr_name(attr):
 def setup_info_parser(subparser):
     """Create the info parser"""
 
-    subparser.add_argument("object", help="Name of object to print info for")
+    subparser.add_argument(
+        "object",
+        help=(
+            "name of object or namespaced spec to print info for "
+            "(e.g., my-app or builtin.app.my-app)"
+        ),
+    )
 
     arguments.add_common_arguments(subparser, ["obj_type"])
 
@@ -473,9 +480,13 @@ def print_info(args):
     format_type = getattr(supported_formats, args.format)
     args.format = format_type
 
-    object_type = ramble.repository.ObjectTypes[args.type]
-    obj_name = args.object
-    obj = ramble.repository.get(obj_name, object_type=object_type)
+    spec = ramble.spec.Spec(args.object)
+    if spec.object_type:
+        object_type = spec.object_type
+    else:
+        object_type = ramble.repository.ObjectTypes[args.type]
+
+    obj = ramble.repository.get(spec, object_type=object_type)
 
     print_object_header(object_type, obj)
 

--- a/lib/ramble/ramble/cmd/create.py
+++ b/lib/ramble/ramble/cmd/create.py
@@ -213,9 +213,6 @@ def create(parser, args):
             name = spec.name
             if spec.namespace:
                 repo = spec.namespace
-        elif args.object_type in type_mapping:
-            obj_type = type_mapping[args.object_type]
-            name = args.name
         else:
             type_map = ramble.repository.get_object_type_map()
             if args.object_type in type_map:

--- a/lib/ramble/ramble/cmd/create.py
+++ b/lib/ramble/ramble/cmd/create.py
@@ -9,6 +9,7 @@
 
 import ramble.creator
 import ramble.repository
+import ramble.spec
 import ramble.util.naming as nm
 from ramble.util.logger import logger
 
@@ -33,8 +34,10 @@ def setup_parser(subparser):
     subparser.add_argument(
         "object_type",
         nargs="?",
-        choices=list(type_mapping.keys()),
-        help="the type of object definition to create",
+        help=(
+            "the type of object definition to create or a namespaced spec "
+            "(e.g., application, or builtin.app.foo)"
+        ),
     )
     subparser.add_argument(
         "name",
@@ -196,11 +199,36 @@ def run_interactive_wizard():
 def create(parser, args):
     """Main command runner logic."""
 
+    obj_type = None
+    name = None
+    repo = args.repo
+    base = args.base
+    maintainers = [m.strip() for m in args.maintainers.split(",")] if args.maintainers else []
+    tags = [t.strip() for t in args.tags.split(",")] if args.tags else []
+
+    if args.object_type:
+        spec = ramble.spec.Spec(args.object_type)
+        if spec.object_type and spec.name:
+            obj_type = spec.object_type
+            name = spec.name
+            if spec.namespace:
+                repo = spec.namespace
+        elif args.object_type in type_mapping:
+            obj_type = type_mapping[args.object_type]
+            name = args.name
+        else:
+            type_map = ramble.repository.get_object_type_map()
+            if args.object_type in type_map:
+                obj_type = type_map[args.object_type]
+                name = args.name
+
     # Check if interactive wizard is requested or needed
-    if args.interactive or not args.object_type or not args.name:
+    if args.interactive or not obj_type or not name:
         import sys
 
         if not sys.stdin.isatty():
+            if args.object_type and not name and obj_type:
+                logger.die(f"Missing name for {args.object_type}.")
             logger.die(
                 "Interactive wizard cannot be run in a non-interactive terminal. "
                 "Please provide 'object_type' and 'name' arguments."
@@ -210,13 +238,6 @@ def create(parser, args):
         except KeyboardInterrupt:
             print("\n\n[ABORTED] Object creation cancelled.")
             return 1
-    else:
-        obj_type = type_mapping[args.object_type]
-        name = args.name
-        repo = args.repo
-        base = args.base
-        maintainers = [m.strip() for m in args.maintainers.split(",")] if args.maintainers else []
-        tags = [t.strip() for t in args.tags.split(",")] if args.tags else []
 
     try:
         file_path, repo_namespace = ramble.creator.create_object(

--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -12,6 +12,7 @@ import os
 import ramble.cmd
 import ramble.paths
 import ramble.repository
+import ramble.spec
 from ramble.util.logger import logger
 
 from spack.util.editor import editor
@@ -142,7 +143,12 @@ def setup_parser(subparser):
     excl_args.add_argument("-r", "--repo", default=None, help="path to repo to edit object in")
     excl_args.add_argument("-N", "--namespace", default=None, help="namespace of object to edit")
 
-    subparser.add_argument("object_name", nargs="?", default=None, help="object name")
+    subparser.add_argument(
+        "object_name",
+        nargs="?",
+        default=None,
+        help=("object name or namespaced spec to edit " "(e.g., my-app or builtin.app.my-app)"),
+    )
 
 
 def edit(parser, args):

--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -26,8 +26,8 @@ def normalize_type_name(type_name):
     if not type_name:
         return None
 
-    # Map aliases
-    aliases = {
+    # Map non-object type aliases
+    extra_type_aliases = {
         "test": "test",
         "tests": "test",
         "command": "command",
@@ -37,18 +37,14 @@ def normalize_type_name(type_name):
         "module": "module",
         "modules": "module",
     }
-    if type_name in aliases:
-        return aliases[type_name]
+    norm_type = type_name.lower().strip().replace(" ", "_")
+    if norm_type in extra_type_aliases:
+        return extra_type_aliases[norm_type]
 
-    # Map singular to plural for ObjectTypes
-    norm_type = type_name.lower().replace("-", " ").replace("_", " ")
-    for obj_type in ramble.repository.ObjectTypes:
-        if norm_type == obj_type.name.lower().replace("_", " "):
-            return obj_type.name
-        if obj_type in ramble.repository.type_definitions:
-            singular = ramble.repository.type_definitions[obj_type]["singular"]
-            if norm_type == singular.lower().replace("_", " ").replace("-", " "):
-                return obj_type.name
+    # Map object types using repository's get_object_type_map()
+    type_map = ramble.repository.get_object_type_map()
+    if norm_type in type_map:
+        return type_map[norm_type].name
 
     return type_name
 
@@ -66,27 +62,36 @@ def find_all_matches(name, repo_path=None, namespace=None, obj_type=None):
     extra_types = ["test", "command", "docs", "module"]
     allowed_types = ramble.repository.OBJECT_NAMES + extra_types
 
-    types_to_check = [obj_type] if obj_type else allowed_types
+    # Parse spec if name might be a namespaced spec
+    spec = ramble.spec.Spec(name)
+    spec_obj_type = spec.object_type.name if spec.object_type else None
+    spec_namespace = spec.namespace
+    spec_name = spec.name if spec.name else name
+
+    effective_obj_type = obj_type or spec_obj_type
+    types_to_check = [effective_obj_type] if effective_obj_type else allowed_types
+
+    effective_namespace = namespace or spec_namespace
 
     for t in types_to_check:
         if t in ramble.repository.OBJECT_NAMES:
             # Check object type
-            obj_type = ramble.repository.ObjectTypes[t]
+            repo_obj_type = ramble.repository.ObjectTypes[t]
             if repo_path:
                 try:
-                    repos = [ramble.repository.Repo(repo_path, object_type=obj_type)]
+                    repos = [ramble.repository.Repo(repo_path, object_type=repo_obj_type)]
                 except Exception:
                     repos = []
-            elif namespace:
+            elif effective_namespace:
                 try:
-                    repos = [ramble.repository.paths[obj_type].get_repo(namespace)]
+                    repos = [ramble.repository.paths[repo_obj_type].get_repo(effective_namespace)]
                 except Exception:
                     repos = []
             else:
-                repos = ramble.repository.paths[obj_type].repos
+                repos = ramble.repository.paths[repo_obj_type].repos
 
             for repo in repos:
-                path = repo.filename_for_object_name(name)
+                path = repo.filename_for_object_name(spec_name)
                 if os.path.isfile(path):
                     matches.append({"type": t, "path": path, "repo_namespace": repo.namespace})
         elif t in extra_types:
@@ -212,7 +217,12 @@ def edit(parser, args):
 
         # If no matches found, reproduce the original behavior/messages:
         # 1. If type is specified/defaulted, we show type-specific "not found" messages.
-        type_name = args.type or ramble.repository.default_type.name
+        spec = ramble.spec.Spec(name)
+        spec_obj_type = spec.object_type.name if spec.object_type else None
+        type_name = args.type or spec_obj_type or ramble.repository.default_type.name
+        effective_namespace = args.namespace or spec.namespace
+        spec_name = spec.name if spec.name else name
+
         type_to_path = {
             "test": ramble.paths.test_path,
             "command": ramble.paths.command_path,
@@ -232,11 +242,11 @@ def edit(parser, args):
                 obj_type = ramble.repository.ObjectTypes[type_name]
                 if args.repo:
                     repo = ramble.repository.Repo(args.repo, object_type=obj_type)
-                elif args.namespace:
-                    repo = ramble.repository.paths[obj_type].get_repo(args.namespace)
+                elif effective_namespace:
+                    repo = ramble.repository.paths[obj_type].get_repo(effective_namespace)
                 else:
                     repo = ramble.repository.paths[obj_type]
-                path = repo.filename_for_object_name(name)
+                path = repo.filename_for_object_name(spec_name)
             except Exception:
                 path = None
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -903,6 +903,7 @@ def workspace_info(args):
 
     # Build an index of experiments to avoid re-rendering them in the loops below
     experiment_index_map = defaultdict(list)
+    app_names_cache = {}
     for exp_name, app_inst, _ in experiment_set.all_experiments():
         experiment_template_name = app_inst.variables[app_inst.keywords.experiment_template_name]
         if app_inst.repeats.repeat_index:
@@ -910,14 +911,19 @@ def workspace_info(args):
             if experiment_template_name.endswith(suffix):
                 experiment_template_name = experiment_template_name[: -len(suffix)]
 
-        app_ns_spec = ramble.spec.Spec(app_inst.variables[app_inst.keywords.application_namespace])
-        app_ns = app_ns_spec.fullname
-        app_name = app_inst.variables[app_inst.keywords.application_name]
-        app_ns_no_type = (
-            f"{app_ns_spec.namespace}.{app_ns_spec.name}" if app_ns_spec.namespace else app_name
-        )
+        app_ns_raw = app_inst.variables[app_inst.keywords.application_namespace]
+        if app_ns_raw not in app_names_cache:
+            app_ns_spec = ramble.spec.Spec(app_ns_raw)
+            app_ns = app_ns_spec.fullname
+            app_name = app_inst.variables[app_inst.keywords.application_name]
+            app_ns_no_type = (
+                f"{app_ns_spec.namespace}.{app_ns_spec.name}"
+                if app_ns_spec.namespace
+                else app_name
+            )
+            app_names_cache[app_ns_raw] = tuple({app_ns, app_name, app_ns_no_type})
 
-        for a_name in {app_ns, app_name, app_ns_no_type}:
+        for a_name in app_names_cache[app_ns_raw]:
             key = (
                 a_name,
                 app_inst.variables[app_inst.keywords.workload_template_name],

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -25,6 +25,7 @@ import ramble.config
 import ramble.expander
 import ramble.filters
 import ramble.pipeline
+import ramble.repository
 import ramble.software_environments
 import ramble.spec
 import ramble.util.colors as color
@@ -914,14 +915,23 @@ def workspace_info(args):
         app_ns_raw = app_inst.variables[app_inst.keywords.application_namespace]
         if app_ns_raw not in app_names_cache:
             app_ns_spec = ramble.spec.Spec(app_ns_raw)
-            app_ns = app_ns_spec.fullname
             app_name = app_inst.variables[app_inst.keywords.application_name]
-            app_ns_no_type = (
-                f"{app_ns_spec.namespace}.{app_ns_spec.name}"
-                if app_ns_spec.namespace
-                else app_name
-            )
-            app_names_cache[app_ns_raw] = tuple({app_ns, app_name, app_ns_no_type})
+            try:
+                repo_ns = (
+                    app_ns_spec.namespace
+                    or ramble.repository.paths[ramble.repository.ObjectTypes.applications]
+                    .repo_for_obj(app_name)
+                    .namespace
+                )
+            except Exception:
+                repo_ns = app_ns_spec.namespace
+
+            names = {app_name, app_ns_spec.fullname, f"app.{app_name}"}
+            if repo_ns:
+                names.add(f"{repo_ns}.{app_name}")
+                names.add(f"{repo_ns}.app.{app_name}")
+
+            app_names_cache[app_ns_raw] = tuple(names)
 
         for a_name in app_names_cache[app_ns_raw]:
             key = (

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -26,6 +26,7 @@ import ramble.expander
 import ramble.filters
 import ramble.pipeline
 import ramble.software_environments
+import ramble.spec
 import ramble.util.colors as color
 import ramble.workspace
 import ramble.workspace.shell
@@ -909,12 +910,20 @@ def workspace_info(args):
             if experiment_template_name.endswith(suffix):
                 experiment_template_name = experiment_template_name[: -len(suffix)]
 
-        key = (
-            app_inst.variables[app_inst.keywords.application_name],
-            app_inst.variables[app_inst.keywords.workload_template_name],
-            experiment_template_name,
+        app_ns_spec = ramble.spec.Spec(app_inst.variables[app_inst.keywords.application_namespace])
+        app_ns = app_ns_spec.fullname
+        app_name = app_inst.variables[app_inst.keywords.application_name]
+        app_ns_no_type = (
+            f"{app_ns_spec.namespace}.{app_ns_spec.name}" if app_ns_spec.namespace else app_name
         )
-        experiment_index_map[key].append(exp_name)
+
+        for a_name in {app_ns, app_name, app_ns_no_type}:
+            key = (
+                a_name,
+                app_inst.variables[app_inst.keywords.workload_template_name],
+                experiment_template_name,
+            )
+            experiment_index_map[key].append(exp_name)
 
     # Construct filters here...
     filters = ramble.filters.Filters(

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -205,6 +205,24 @@ _ALL_ACCEPTED_CONFIGS = {
 }
 
 
+@functools.lru_cache(maxsize=1)
+def get_object_type_map():
+    """Returns a mapping from string representations of object types (singular,
+    plural, abbrev, hyphens/underscores) to their corresponding ObjectType enum."""
+    mapping = {}
+    for obj_type, type_def in type_definitions.items():
+        candidates = set()
+        for key in ("abbrev", "dir_name", "singular"):
+            val = type_def.get(key)
+            if val:
+                val = val.replace(" ", "_")
+                candidates.update([val, val.replace("_", "-"), val.replace("-", "_")])
+
+        for cand in candidates:
+            mapping[cand] = obj_type
+    return mapping
+
+
 def _gen_path(repo_dirs=None, obj_type=default_type):
     """Create a RepoPath for a specific object, add it to sys.meta_path, and return it."""
     section_name = type_definitions[obj_type]["config_section"]

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -1241,12 +1241,12 @@ class Repo:
         obj_dir = self.dirname_for_object_name(obj_name)
         return os.path.join(obj_dir, self.object_file_name)
 
-    @autospec
     def object_path(self, spec):
+        spec_name = spec.name if isinstance(spec, ramble.spec.Spec) else spec
         return os.path.join(
             self.objects_path,
-            self.dirname_for_object_name(spec.name),
-            self.filename_for_object_name(spec.name),
+            self.dirname_for_object_name(spec_name),
+            self.filename_for_object_name(spec_name),
         )
 
     @property

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -10,6 +10,7 @@ import io
 from typing import Mapping
 
 import ramble.error
+import ramble.repository
 import ramble.util.colors as clr
 
 color_formats: Mapping[str, str] = {}
@@ -17,30 +18,59 @@ default_format = "{name}"
 
 
 class Spec:
-    def __init__(self, spec_like=None):
+    def __init__(self, spec_like=None, object_type=None):
         """Create a new Spec.
 
         Arguments:
-          spec_like (optional string): If not provided we initialize an
+          spec_like (optional string or Spec): If not provided we initialize an
           anonymous Spec that matches any Spec object; if provided we parse
           this as a Spec string.
+          object_type (optional ObjectTypes): Optional object type enum.
         """
 
         # Copy if spec_like is a Spec.
         if isinstance(spec_like, Spec):
             self._dup(spec_like)
+            if object_type is not None:
+                self.object_type = object_type
             return
 
         # init an empty spec that matches anything.
         self.name = None
         self.namespace = None
+        self.object_type = object_type
 
         if isinstance(spec_like, str):
-            namespace, _, spec_name = spec_like.rpartition(".")
-            if not namespace:
-                namespace = None
-            self.name = spec_name
-            self.namespace = namespace
+            self._parse_spec_string(spec_like)
+
+    def _parse_spec_string(self, spec_like):
+        if not spec_like:
+            self.name = ""
+            self.namespace = None
+            return
+
+        # Strip any version suffix if present (e.g., app@1.0)
+        spec_like = spec_like.partition("@")[0]
+
+        parts = spec_like.split(".")
+
+        type_map = ramble.repository.get_object_type_map()
+
+        if len(parts) >= 3 and parts[-2] in type_map:
+            self.object_type = type_map[parts[-2]]
+            self.name = parts[-1]
+            self.namespace = ".".join(parts[:-2])
+        elif len(parts) >= 2:
+            if len(parts) == 2 and parts[0] in type_map:
+                self.object_type = type_map[parts[0]]
+                self.name = parts[1]
+                self.namespace = None
+            else:
+                self.name = parts[-1]
+                self.namespace = ".".join(parts[:-1])
+        else:
+            self.name = parts[0]
+            self.namespace = None
 
     def copy(self):
         new_spec = Spec()
@@ -50,6 +80,7 @@ class Spec:
     def _dup(self, other):
         self.name = other.name
         self.namespace = other.namespace
+        self.object_type = getattr(other, "object_type", None)
 
     def format(self, format_string=default_format, **kwargs):
         r"""Prints out particular pieces of a spec, depending on what is
@@ -160,15 +191,20 @@ class Spec:
         return self.format(*args, **kwargs)
 
     def __str__(self):
-        return self.name
+        return self.name if self.name is not None else ""
 
     @property
     def fullname(self):
-        return (
-            (f"{self.namespace}.{self.name}")
-            if self.namespace
-            else (self.name if self.name else "")
-        )
+        if self.namespace:
+            if self.object_type:
+                abbrev = ramble.repository.type_definitions[self.object_type]["abbrev"]
+                return f"{self.namespace}.{abbrev}.{self.name}"
+            return f"{self.namespace}.{self.name}"
+        else:
+            if self.object_type:
+                abbrev = ramble.repository.type_definitions[self.object_type]["abbrev"]
+                return f"{abbrev}.{self.name}"
+            return self.name if self.name else ""
 
 
 class SpecFormatStringError(ramble.error.SpecError):

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -23,7 +23,7 @@ def _parse_spec_string(spec_like):
         return "", None, None
 
     # Strip any version suffix if present (e.g., app@1.0)
-    spec_like = spec_like.partition("@")[0]
+    spec_like = spec_like.partition("@")[0].lower()
 
     parts = spec_like.split(".")
 

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -6,15 +6,50 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import functools
 import io
 from typing import Mapping
 
 import ramble.error
-import ramble.repository
 import ramble.util.colors as clr
 
 color_formats: Mapping[str, str] = {}
 default_format = "{name}"
+
+
+@functools.lru_cache(maxsize=None)
+def _parse_spec_string(spec_like):
+    if not spec_like:
+        return "", None, None
+
+    # Strip any version suffix if present (e.g., app@1.0)
+    spec_like = spec_like.partition("@")[0]
+
+    parts = spec_like.split(".")
+
+    import ramble.repository
+
+    type_map = ramble.repository.get_object_type_map()
+
+    if len(parts) >= 3 and parts[-2] in type_map:
+        object_type = type_map[parts[-2]]
+        name = parts[-1]
+        namespace = ".".join(parts[:-2])
+    elif len(parts) >= 2:
+        if len(parts) == 2 and parts[0] in type_map:
+            object_type = type_map[parts[0]]
+            name = parts[1]
+            namespace = None
+        else:
+            object_type = None
+            name = parts[-1]
+            namespace = ".".join(parts[:-1])
+    else:
+        object_type = None
+        name = parts[0]
+        namespace = None
+
+    return name, namespace, object_type
 
 
 class Spec:
@@ -44,33 +79,9 @@ class Spec:
             self._parse_spec_string(spec_like)
 
     def _parse_spec_string(self, spec_like):
-        if not spec_like:
-            self.name = ""
-            self.namespace = None
-            return
-
-        # Strip any version suffix if present (e.g., app@1.0)
-        spec_like = spec_like.partition("@")[0]
-
-        parts = spec_like.split(".")
-
-        type_map = ramble.repository.get_object_type_map()
-
-        if len(parts) >= 3 and parts[-2] in type_map:
-            self.object_type = type_map[parts[-2]]
-            self.name = parts[-1]
-            self.namespace = ".".join(parts[:-2])
-        elif len(parts) >= 2:
-            if len(parts) == 2 and parts[0] in type_map:
-                self.object_type = type_map[parts[0]]
-                self.name = parts[1]
-                self.namespace = None
-            else:
-                self.name = parts[-1]
-                self.namespace = ".".join(parts[:-1])
-        else:
-            self.name = parts[0]
-            self.namespace = None
+        self.name, self.namespace, parsed_type = _parse_spec_string(spec_like)
+        if self.object_type is None:
+            self.object_type = parsed_type
 
     def copy(self):
         new_spec = Spec()
@@ -195,6 +206,10 @@ class Spec:
 
     @property
     def fullname(self):
+        if not self.name:
+            return ""
+        import ramble.repository
+
         if self.namespace:
             if self.object_type:
                 abbrev = ramble.repository.type_definitions[self.object_type]["abbrev"]
@@ -204,7 +219,7 @@ class Spec:
             if self.object_type:
                 abbrev = ramble.repository.type_definitions[self.object_type]["abbrev"]
                 return f"{abbrev}.{self.name}"
-            return self.name if self.name else ""
+            return self.name
 
 
 class SpecFormatStringError(ramble.error.SpecError):

--- a/lib/ramble/ramble/test/cmd/create.py
+++ b/lib/ramble/ramble/test/cmd/create.py
@@ -7,9 +7,11 @@
 # except according to those terms.
 
 import os
+import sys
 
 import pytest
 
+import ramble.repository
 from ramble.error import RambleCommandError
 from ramble.main import RambleCommand
 
@@ -248,11 +250,7 @@ def test_create_missing_template(mutable_config, tmpdir, monkeypatch):
     repo_cmd("create", repo_path, "mockrepo")
     repo_cmd("add", "-t", "applications", "--scope=site", repo_path)
 
-    import ramble.repository
-
     ramble.repository.paths[ramble.repository.ObjectTypes.applications]._instance = None
-
-    import os
 
     orig_exists = os.path.exists
 
@@ -271,8 +269,6 @@ def test_create_missing_template(mutable_config, tmpdir, monkeypatch):
             content = f.read()
             assert "class MyMissingTplApp:" in content
     finally:
-        import ramble.repository
-
         ramble.repository.paths[ramble.repository.ObjectTypes.applications]._instance = None
 
 
@@ -284,11 +280,7 @@ def test_create_interactive_wizard(mutable_config, tmpdir, monkeypatch):
     repo_cmd("create", repo_path, repo_name)
     repo_cmd("add", "-t", "applications", "--scope=site", repo_path)
 
-    import ramble.repository
-
     ramble.repository.paths[ramble.repository.ObjectTypes.applications]._instance = None
-
-    import sys
 
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
 
@@ -315,11 +307,7 @@ def test_create_interactive_wizard_validation_and_abort(mutable_config, tmpdir, 
     repo_cmd("create", repo_path, repo_name)
     repo_cmd("add", "-t", "applications", "--scope=site", repo_path)
 
-    import ramble.repository
-
     ramble.repository.paths[ramble.repository.ObjectTypes.applications]._instance = None
-
-    import sys
 
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
 
@@ -341,3 +329,82 @@ def test_create_interactive_wizard_validation_and_abort(mutable_config, tmpdir, 
     # create_cmd should exit gracefully without raising exception
     out = create_cmd("-i", fail_on_error=False)
     assert "[ABORTED] Object creation cancelled" in out
+
+
+@pytest.mark.parametrize(
+    "spec_arg, expected_dir, expected_name, expected_file, expected_content",
+    [
+        (
+            "mockrepo.app.spec-app",
+            "applications",
+            "spec-app",
+            "application.py",
+            "class SpecApp(ExecutableApplication):",
+        ),
+        (
+            "mockrepo.application.spec-app2",
+            "applications",
+            "spec-app2",
+            "application.py",
+            "class SpecApp2(ExecutableApplication):",
+        ),
+        (
+            "mockrepo.mod.spec-mod",
+            "modifiers",
+            "spec-mod",
+            "modifier.py",
+            "class SpecMod(BasicModifier):",
+        ),
+        (
+            "mockrepo.sys.spec-sys",
+            "systems",
+            "spec-sys",
+            "system.py",
+            "class SpecSys:",
+        ),
+    ],
+)
+def test_create_namespaced_spec(
+    mutable_config,
+    tmpdir,
+    spec_arg,
+    expected_dir,
+    expected_name,
+    expected_file,
+    expected_content,
+):
+    """Verify object creation using namespaced specs (repo.type.name)."""
+    repo_path = str(tmpdir.join("test_repo"))
+    repo_ns = "mockrepo"
+
+    try:
+        for t in ramble.repository.ObjectTypes:
+            try:
+                ramble.repository.paths[t]._instance = None
+            except Exception:
+                pass
+
+        repo_cmd("create", repo_path, repo_ns)
+        repo_cmd("add", "-t", expected_dir, "--scope=site", repo_path)
+
+        for t in ramble.repository.ObjectTypes:
+            try:
+                ramble.repository.paths[t]._instance = None
+            except Exception:
+                pass
+
+        create_cmd(spec_arg)
+
+        full_path = os.path.join(repo_path, expected_dir, expected_name, expected_file)
+        assert os.path.exists(full_path)
+
+        with open(full_path, encoding="utf-8") as f:
+            content = f.read()
+            assert expected_content in content
+
+    finally:
+        for t in ramble.repository.ObjectTypes:
+            try:
+                ramble.repository.paths[t]._instance = None
+            except Exception:
+                pass

--- a/lib/ramble/ramble/test/cmd/create.py
+++ b/lib/ramble/ramble/test/cmd/create.py
@@ -105,19 +105,13 @@ def test_create_parameterized(
         import ramble.repository
 
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
 
         repo_cmd("create", repo_path, repo_ns)
         repo_cmd("add", "-t", f"{obj_type}s", "--scope=site", repo_path)
 
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
 
         parsed_args = [obj_type, obj_name] + actual_args
         if "--repo" not in actual_args and not fallback:
@@ -145,10 +139,7 @@ def test_create_parameterized(
         import ramble.repository
 
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
 
 
 def test_create_interactive_non_tty(mutable_config):
@@ -379,19 +370,13 @@ def test_create_namespaced_spec(
 
     try:
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
 
         repo_cmd("create", repo_path, repo_ns)
         repo_cmd("add", "-t", expected_dir, "--scope=site", repo_path)
 
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
 
         create_cmd(spec_arg)
 
@@ -404,7 +389,62 @@ def test_create_namespaced_spec(
 
     finally:
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
+
+
+@pytest.mark.parametrize(
+    "type_alias, obj_name, expected_dir, expected_file, expected_content",
+    [
+        (
+            "app",
+            "alias-app",
+            "applications",
+            "application.py",
+            "class AliasApp(ExecutableApplication):",
+        ),
+        (
+            "applications",
+            "plural-app",
+            "applications",
+            "application.py",
+            "class PluralApp(ExecutableApplication):",
+        ),
+        ("mod", "alias-mod", "modifiers", "modifier.py", "class AliasMod(BasicModifier):"),
+        ("sys", "alias-sys", "systems", "system.py", "class AliasSys:"),
+    ],
+)
+def test_create_object_type_alias(
+    mutable_config,
+    tmpdir,
+    type_alias,
+    obj_name,
+    expected_dir,
+    expected_file,
+    expected_content,
+):
+    """Verify object creation using object type aliases and abbreviations (e.g., app, mod, sys)."""
+    repo_path = str(tmpdir.join("test_repo"))
+    repo_ns = "mockrepo"
+
+    try:
+        for t in ramble.repository.ObjectTypes:
+            ramble.repository.paths[t]._instance = None
+
+        repo_cmd("create", repo_path, repo_ns)
+        repo_cmd("add", "-t", expected_dir, "--scope=site", repo_path)
+
+        for t in ramble.repository.ObjectTypes:
+            ramble.repository.paths[t]._instance = None
+
+        create_cmd(type_alias, obj_name, "--repo", repo_path)
+
+        full_path = os.path.join(repo_path, expected_dir, obj_name, expected_file)
+        assert os.path.exists(full_path)
+
+        with open(full_path, encoding="utf-8") as f:
+            content = f.read()
+            assert expected_content in content
+
+    finally:
+        for t in ramble.repository.ObjectTypes:
+            ramble.repository.paths[t]._instance = None

--- a/lib/ramble/ramble/test/cmd/edit.py
+++ b/lib/ramble/ramble/test/cmd/edit.py
@@ -148,11 +148,41 @@ def test_edit_deduction_fails_correctly():
     assert "No application for 'non-existent-object-name' was found" in output
 
 
-def test_normalize_type_name_empty():
+def test_normalize_type_name():
     from ramble.cmd.edit import normalize_type_name
 
     assert normalize_type_name(None) is None
     assert normalize_type_name("") is None
+    assert normalize_type_name("app") == "applications"
+    assert normalize_type_name("application") == "applications"
+    assert normalize_type_name("applications") == "applications"
+    assert normalize_type_name("mod") == "modifiers"
+    assert normalize_type_name("modifier") == "modifiers"
+    assert normalize_type_name("modifiers") == "modifiers"
+    assert normalize_type_name("pkg_man") == "package_managers"
+    assert normalize_type_name("package-manager") == "package_managers"
+    assert normalize_type_name("package_manager") == "package_managers"
+    assert normalize_type_name("package manager") == "package_managers"
+    assert normalize_type_name("test") == "test"
+    assert normalize_type_name("tests") == "test"
+    assert normalize_type_name("command") == "command"
+    assert normalize_type_name("commands") == "command"
+    assert normalize_type_name("doc") == "docs"
+    assert normalize_type_name("docs") == "docs"
+    assert normalize_type_name("module") == "module"
+    assert normalize_type_name("modules") == "module"
+    assert normalize_type_name("TEST") == "test"
+    assert normalize_type_name("Command") == "command"
+    assert normalize_type_name("APP") == "applications"
+    assert normalize_type_name("MODIFIER") == "modifiers"
+    assert normalize_type_name("unknown_type") == "unknown_type"
+
+
+def test_edit_abbreviated_type(mock_modifiers, mock_editor):
+    """Test `ramble edit -t mod info` normalizes abbreviated type"""
+    edit("info", "-t", "mod")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/modifiers/info/modifier.py" in mock_editor[0]
 
 
 def test_edit_object_is_directory(mock_applications, monkeypatch):

--- a/lib/ramble/ramble/test/cmd/edit.py
+++ b/lib/ramble/ramble/test/cmd/edit.py
@@ -254,3 +254,31 @@ def test_edit_no_name_no_editor(monkeypatch):
     monkeypatch.setattr("ramble.cmd.edit.editor", mock_fail_editor)
     output = edit(fail_on_error=False)
     assert "No valid editor was found" in output
+
+
+def test_edit_namespaced_spec_with_type(mock_modifiers, mock_editor):
+    """Test `ramble edit <repo>.<type>.<name>` covers lines 36 and 41 in edit.py."""
+    edit("builtin.mock.mod.info")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/modifiers/info/modifier.py" in mock_editor[0]
+
+
+def test_edit_namespaced_spec_without_type(mock_applications, mock_editor):
+    """Test `ramble edit <repo>.<name>` covers line 41 in edit.py."""
+    edit("builtin.mock.basic")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/applications/basic/application.py" in mock_editor[0]
+
+
+def test_edit_repo_path(mock_applications, mock_editor):
+    """Test `ramble edit --repo <path> <name>` covers line 47 in edit.py."""
+    import ramble.repository
+
+    repo_dir = (
+        ramble.repository.paths[ramble.repository.ObjectTypes.applications]
+        .get_repo("builtin.mock")
+        .root
+    )
+    edit("--repo", repo_dir, "basic")
+    assert len(mock_editor) == 1
+    assert "repos/builtin.mock/applications/basic/application.py" in mock_editor[0]

--- a/lib/ramble/ramble/test/cmd/info.py
+++ b/lib/ramble/ramble/test/cmd/info.py
@@ -456,19 +456,13 @@ def test_info_namespaced_spec(mutable_config, tmpdir):
 
     try:
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
 
         repo("create", repo_path, repo_ns)
         repo("add", "-t", "applications", "--scope=site", repo_path)
 
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None
 
         create(f"{repo_ns}.app.test-app")
 
@@ -477,7 +471,4 @@ def test_info_namespaced_spec(mutable_config, tmpdir):
 
     finally:
         for t in ramble.repository.ObjectTypes:
-            try:
-                ramble.repository.paths[t]._instance = None
-            except Exception:
-                pass
+            ramble.repository.paths[t]._instance = None

--- a/lib/ramble/ramble/test/cmd/info.py
+++ b/lib/ramble/ramble/test/cmd/info.py
@@ -13,9 +13,12 @@ from typing import Dict, List
 import pytest
 
 import ramble.cmd.common.info
+import ramble.repository
 from ramble.main import RambleCommand
 
 info = RambleCommand("info")
+repo = RambleCommand("repo")
+create = RambleCommand("create")
 
 
 @pytest.fixture(scope="module")
@@ -445,3 +448,36 @@ def test_info_conflicts_pattern(mutable_mock_apps_repo):
     )
     assert "turn_on_required_directives=True" not in out
     assert "turn_on_required_directives conflicts with variant_default" not in out
+
+
+def test_info_namespaced_spec(mutable_config, tmpdir):
+    repo_path = str(tmpdir.join("test_repo"))
+    repo_ns = "mockrepo"
+
+    try:
+        for t in ramble.repository.ObjectTypes:
+            try:
+                ramble.repository.paths[t]._instance = None
+            except Exception:
+                pass
+
+        repo("create", repo_path, repo_ns)
+        repo("add", "-t", "applications", "--scope=site", repo_path)
+
+        for t in ramble.repository.ObjectTypes:
+            try:
+                ramble.repository.paths[t]._instance = None
+            except Exception:
+                pass
+
+        create(f"{repo_ns}.app.test-app")
+
+        out = info(f"{repo_ns}.app.test-app")
+        assert "Description" in out
+
+    finally:
+        for t in ramble.repository.ObjectTypes:
+            try:
+                ramble.repository.paths[t]._instance = None
+            except Exception:
+                pass

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -339,6 +339,20 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '1'
+    builtin.mock.basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '3'
+    app.basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '4'
 """
 
     ws1 = ramble.workspace.create(workspace_name)
@@ -355,8 +369,12 @@ ramble:
 
     assert "Application: builtin.mock.app.basic" in output
     assert "Application: basic" in output
+    assert "Application: builtin.mock.basic" in output
+    assert "Application: app.basic" in output
     assert "builtin.mock.app.basic.test_wl.test_experiment" in output
     assert "basic@1.0.test_wl.test_experiment" in output
+    assert "builtin.mock.basic.test_wl.test_experiment" in output
+    assert "app.basic.test_wl.test_experiment" in output
 
 
 def test_workspace_info_prints_all_levels(workspace_name):

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -137,7 +137,8 @@ def test_workspace_activate_fails(mutable_mock_workspace_path):
     assert "To set up shell support" in out
 
 
-def test_workspace_activate_prompt(workspace_name):
+def test_workspace_activate_prompt(workspace_name, monkeypatch):
+    monkeypatch.delenv("TERM", raising=False)
     ramble.workspace.deactivate()
     ws = ramble.workspace.create(workspace_name)
     ws.write()
@@ -311,6 +312,51 @@ ramble:
     output = workspace("info", "--software", global_args=["-w", workspace_name])
 
     check_info_basic(output)
+
+
+def test_workspace_info_namespaced_application(workspace_name, mutable_mock_apps_repo):
+    test_config = """
+ramble:
+  config:
+    enable_strict_versions: false
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '5'
+    n_ranks: '{processes_per_node}*{n_nodes}'
+  applications:
+    builtin.mock.app.basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '2'
+    basic@1.0:
+      workloads:
+        test_wl:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '1'
+"""
+
+    ws1 = ramble.workspace.create(workspace_name)
+    ws1.write()
+
+    config_path = os.path.join(ws1.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+
+    with open(config_path, "w+", encoding="utf-8") as f:
+        f.write(test_config)
+
+    ws1._re_read()
+
+    output = workspace("info", global_args=["-w", workspace_name])
+
+    assert "Application: builtin.mock.app.basic" in output
+    assert "Application: basic" in output
+    assert "builtin.mock.app.basic.test_wl.test_experiment" in output
+    assert "basic@1.0.test_wl.test_experiment" in output
 
 
 def test_workspace_info_prints_all_levels(workspace_name):

--- a/lib/ramble/ramble/test/spec.py
+++ b/lib/ramble/ramble/test/spec.py
@@ -29,6 +29,11 @@ class TestSpec:
             ("org.project.repo.foo", "foo", "org.project.repo", "org.project.repo.foo"),
             ("foo@1.0", "foo", None, "foo"),
             ("builtin.app.foo@1.0", "foo", "builtin", "builtin.app.foo"),
+            ("MY-APP", "my-app", None, "my-app"),
+            ("Builtin.App.Foo", "foo", "builtin", "builtin.app.foo"),
+            ("APP.FOO", "foo", None, "app.foo"),
+            ("BUILTIN.APPLICATION.FOO@1.0", "foo", "builtin", "builtin.app.foo"),
+            ("Builtin.Foo", "foo", "builtin", "builtin.foo"),
         ],
     )
     def test_init_from_string(

--- a/lib/ramble/ramble/test/spec.py
+++ b/lib/ramble/ramble/test/spec.py
@@ -20,6 +20,15 @@ class TestSpec:
             ("my-app", "my-app", None, "my-app"),
             ("my-namespace.my-app", "my-app", "my-namespace", "my-namespace.my-app"),
             ("", "", None, ""),
+            ("builtin.app.foo", "foo", "builtin", "builtin.app.foo"),
+            ("builtin.application.foo", "foo", "builtin", "builtin.app.foo"),
+            ("builtin.mod.bar", "bar", "builtin", "builtin.mod.bar"),
+            ("builtin.sys.my_sys", "my_sys", "builtin", "builtin.sys.my_sys"),
+            ("app.foo", "foo", None, "app.foo"),
+            ("org.project.repo.app.foo", "foo", "org.project.repo", "org.project.repo.app.foo"),
+            ("org.project.repo.foo", "foo", "org.project.repo", "org.project.repo.foo"),
+            ("foo@1.0", "foo", None, "foo"),
+            ("builtin.app.foo@1.0", "foo", "builtin", "builtin.app.foo"),
         ],
     )
     def test_init_from_string(
@@ -36,9 +45,11 @@ class TestSpec:
         assert s_empty.name is None
         assert s_empty.namespace is None
         assert s_empty.fullname == ""
+        assert str(s_empty) == ""
 
         # Test init from another spec and copy method
         s1 = Spec("my-namespace.my-app")
+        assert str(s1) == "my-app"
         s2 = Spec(s1)
         s3 = s1.copy()
 

--- a/lib/ramble/ramble/test/workspace.py
+++ b/lib/ramble/ramble/test/workspace.py
@@ -224,3 +224,47 @@ def test_all_applications_with_version_and_namespace(mutable_mock_workspace_path
             workspace.deactivate()
         if os.path.exists(ws_root):
             shutil.rmtree(ws_root)
+
+
+def test_all_applications_application_configs(mutable_mock_workspace_path):
+    ws_name = "test-ws-app-configs"
+    ws_root = workspace.root(ws_name)
+    ws = None
+
+    if os.path.exists(ws_root):
+        shutil.rmtree(ws_root)
+
+    try:
+        ws = workspace.create(ws_name)
+        workspace.activate(ws)
+
+        ws.application_configs = {
+            "app_conf_1": {
+                "filename": "app_conf_1.yaml",
+                "path": "/fake/path/app_conf_1.yaml",
+                "raw_yaml": None,
+                "yaml": {
+                    ramble.namespace.namespace.application: {
+                        "builtin.app.wrfv3@3.9": {ramble.namespace.namespace.workload: {}},
+                        "hostname@2.0": {ramble.namespace.namespace.workload: {}},
+                        "basic": {ramble.namespace.namespace.workload: {}},
+                    }
+                },
+            }
+        }
+
+        apps = {}
+        for contents, app_context in ws.all_applications():
+            apps[app_context.context_name] = contents.get(ramble.namespace.namespace.version)
+
+        assert "builtin.app.wrfv3" in apps
+        assert apps["builtin.app.wrfv3"] == "3.9"
+        assert "hostname" in apps
+        assert apps["hostname"] == "2.0"
+        assert "basic" in apps
+        assert apps["basic"] is None
+    finally:
+        if ws:
+            workspace.deactivate()
+        if os.path.exists(ws_root):
+            shutil.rmtree(ws_root)

--- a/lib/ramble/ramble/test/workspace.py
+++ b/lib/ramble/ramble/test/workspace.py
@@ -186,3 +186,41 @@ def test_add_experiments_with_zips(make_workspace_from_config):
     exp_config = app_config["basic"]["workloads"]["test_wl"]["experiments"]["test_exp"]
     assert "zips" in exp_config
     assert exp_config["zips"]["my_zip"] == ["var1", "var2"]
+
+
+def test_all_applications_with_version_and_namespace(mutable_mock_workspace_path):
+    ws_name = "test-ws-app-versions"
+    ws_root = workspace.root(ws_name)
+    ws = None
+
+    if os.path.exists(ws_root):
+        shutil.rmtree(ws_root)
+
+    try:
+        ws = workspace.create(ws_name)
+        workspace.activate(ws)
+
+        ramble.config.add(
+            "applications:builtin.app.hostname@1.0:workloads:test_wl:experiments:{}",
+            scope=ws.ws_file_config_scope_name(),
+        )
+        ramble.config.add(
+            "applications:basic@2.0:workloads:test_wl:experiments:{}",
+            scope=ws.ws_file_config_scope_name(),
+        )
+        ws.write()
+        ws._re_read()
+
+        apps = {}
+        for contents, app_context in ws.all_applications():
+            apps[app_context.context_name] = contents.get(ramble.namespace.namespace.version)
+
+        assert "builtin.app.hostname" in apps
+        assert apps["builtin.app.hostname"] == "1.0"
+        assert "basic" in apps
+        assert apps["basic"] == "2.0"
+    finally:
+        if ws:
+            workspace.deactivate()
+        if os.path.exists(ws_root):
+            shutil.rmtree(ws_root)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -33,6 +33,7 @@ import ramble.schema.applications
 import ramble.schema.merged
 import ramble.schema.workspace
 import ramble.software_environments
+import ramble.spec
 import ramble.util.hashing
 import ramble.util.install_cache
 import ramble.util.lock as lk
@@ -910,6 +911,9 @@ ramble:
             if maybe_version:
                 contents[namespace.version] = maybe_version
 
+            app_spec = ramble.spec.Spec(app_name)
+            app_name = app_spec.fullname
+
             application_context = ramble.context.create_context_from_dict(app_name, contents)
 
             yield contents, application_context
@@ -926,6 +930,9 @@ ramble:
                 app_name, _, maybe_version = application.partition("@")
                 if maybe_version:
                     contents[namespace.version] = maybe_version
+
+                app_spec = ramble.spec.Spec(app_name)
+                app_name = app_spec.fullname
 
                 application_context = ramble.context.create_context_from_dict(app_name, contents)
 


### PR DESCRIPTION
Allows namespaced specs (e.g., builtin.app.wrf) to be used in place of object names and arguments indicating repo and type.