### PR TITLE
eval vars per workload

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1341,12 +1341,12 @@ ramble:
             exp_context.variables[workload_name_variable] = workload_names.copy()
             workload_names = [ramble.expander.Expander.expansion_str(workload_name_variable)]
 
-        missing_vars = set()
         self.software_environments = ramble.software_environments.SoftwareEnvironments(self)
         is_dry_run = self.dry_run
         self.dry_run = True
         for workload_name in workload_names:
             edited = True
+            missing_vars = set()
             exp_set = ramble.experiment_set.ExperimentSet(self)
             exp_list = exp_set.render_experiment_set(
                 app_inst.name,

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -4777,8 +4777,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     value = 0
 
                 if value is not None:
-                    self.missing_mpi_variables.add(var_name)
                     self.define_variable(var_name, value)
+                else:
+                    self.missing_mpi_variables.add(var_name)
 
             if mpi_required:
                 required_dict = {


### PR DESCRIPTION
Move `missing_vars` into the loop so different workloads can have different required vars (since some may be MPI, and others not) 

Prior to this fix non-mpi apps would have mpi vars set by `workload manage`

```
           local:
             experiments:
               generated:
                variables:
                  n_nodes: ''
                  n_ranks: ''
                  processes_per_node: ''
```

This now yields:

```
         local:
            experiments:
              generated:
                variables: {}
```