### PR TITLE
Make ramble consider '' as unset and error correctly

### DIFF
--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -4747,7 +4747,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for mpi_var in self.mpi_definitions:
             if mpi_var in self.variables:
                 val = self.variables[mpi_var]
-                if val != "" and val is not None:
+                if val is not None and str(val).strip() != "":
                     mpi_vars_defined.add(mpi_var)
 
         return mpi_vars_defined

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -4746,7 +4746,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         for mpi_var in self.mpi_definitions:
             if mpi_var in self.variables:
-                mpi_vars_defined.add(mpi_var)
+                val = self.variables[mpi_var]
+                if val != "" and val is not None:
+                    mpi_vars_defined.add(mpi_var)
 
         return mpi_vars_defined
 
@@ -4777,8 +4779,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     value = 0
 
                 if value is not None:
-                    self.missing_mpi_variables.add(var_name)
                     self.define_variable(var_name, value)
+                else:
+                    self.missing_mpi_variables.add(var_name)
 
             if mpi_required:
                 required_dict = {


### PR DESCRIPTION
Setting `n_ranks: ''` (which is sometimes down by `workspace manage experiments`) used to give this misleading error:

```
  File "/Users/robertbird/ramble/var/ramble/repos/builtin/base_classes/application-base/base_class.py", line 1298, in run_phase
    phase_func(workspace, app_inst=self)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/robertbird/ramble/var/ramble/repos/builtin/base_applications/hpl/base_application.py", line 363, in _calculate_values
    nNodes = int(expander.expand_var_name("n_nodes"))
ValueError: invalid literal for int() with base 10: ''
Processing phase calculate_values (2/7):  29%|===========>
```

This PR means that value is no ignored so the appropriate instruction to the user is issued requiring a valid value:

```
==> Error: Invalid number of required variables defined.
Two or more of the following are required to be defined.
  - n_ranks
  - processes_per_node
  - n_nodes
Experiment hpl.standard.generated only has:
  - processes_per_node
  - ```