### PR TITLE
introduce standard containerized variant

### DIFF
--- a/etc/ramble/defaults/variants.yaml
+++ b/etc/ramble/defaults/variants.yaml
@@ -1,2 +1,3 @@
 variants:
   system: user-managed
+  containerized: false

--- a/etc/ramble/defaults/variants.yaml
+++ b/etc/ramble/defaults/variants.yaml
@@ -1,3 +1,2 @@
 variants:
   system: user-managed
-  containerized: false

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -66,6 +66,7 @@ class namespace:
     system = "system"
     platform = "platform"
     version = "version"
+    containerized = "containerized"
 
     metadata = "metadata"
     include = "include"

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -736,3 +736,53 @@ def test_workflow_manager_containerized_propagation(request):
         exp_set = ws.build_experiment_set()
         for _, app, _ in exp_set.all_experiments():
             assert not app.object_variants.value("containerized")
+
+
+def test_containerized_app_variable_guarding(request):
+    ws_name = request.node.name
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+        # Define mpi_command variable to satisfy keyword validation
+        config("add", "variables:mpi_command:mpirun -n {n_ranks}", global_args=global_args)
+
+        # By default, workflow manager is user-managed, so containerized=False.
+        # Verify container_only_var is NOT defined as a workload variable.
+        ws._re_read()
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert "container_only_var" not in app.variables
+
+        # Switch to a containerized workflow manager (gke-mpi)
+        config("add", "variants:workflow_manager:gke-mpi", global_args=global_args)
+        ws._re_read()
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert "container_only_var" in app.variables
+
+        # Switch back to user-managed workflow manager but explicitly set containerized: true
+        config("add", "variants:workflow_manager:user-managed", global_args=global_args)
+        config("add", "variants:containerized:true", global_args=global_args)
+        ws._re_read()
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert "container_only_var" in app.variables

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -644,3 +644,95 @@ def test_boolean_variant_output_formatting():
 
     sorted_output = sorted(output_set, key=when_order)
     assert sorted_output == ["str_var=foo", "+bool_var", "~false_var"]
+
+
+def test_containerized_reserved_variant(request):
+    ws_name = request.node.name
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+        ws._re_read()
+
+        # Verify it validates correctly without errors
+        workspace("concretize", global_args=global_args)
+
+        # Verify containerized is in reserved_variants and validate_variant raises an error
+        # for custom definitions, but works for the workspace.
+        with pytest.raises(ramble.variants.RambleVariantError):
+            ramble.variants.validate_variant("containerized")
+
+        # Verify that containerized is false by default in workspace config context
+        # (It should load from etc/ramble/defaults/variants.yaml)
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert not app.object_variants.value("containerized")
+
+        # Set it to true in workspace config and verify
+        config("add", "variants:containerized:true", global_args=global_args)
+        ws._re_read()
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert app.object_variants.value("containerized")
+
+
+def test_workflow_manager_containerized_propagation(request):
+    ws_name = request.node.name
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+        # Define mpi_command variable to satisfy keyword validation
+        config("add", "variables:mpi_command:mpirun -n {n_ranks}", global_args=global_args)
+
+        # Set workflow manager to gke-mpi (containerized)
+        config("add", "variants:workflow_manager:gke-mpi", global_args=global_args)
+        ws._re_read()
+
+        # Verify it defaults to containerized=True
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert app.object_variants.value("containerized")
+
+        # Now set it explicitly to false, and verify it respects the user override
+        config("add", "variants:containerized:false", global_args=global_args)
+        ws._re_read()
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert not app.object_variants.value("containerized")

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -29,6 +29,7 @@ reserved_variants = {
     "is_repeat_child",
     "is_repeat_parent",
     "repeat_index",
+    "containerized",
 }
 
 variant_types = Enum("variant_types", ["default", "experiment", "version"])

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -75,6 +75,14 @@ class WhenVariants(ExecutableApplication):
         workloads=["*"],
     )
 
+    with when("+containerized"):
+        workload_variable(
+            "container_only_var",
+            default="container_val",
+            description="Variable only defined in container",
+            workloads=["*"],
+        )
+
     variant(
         "templated_validation",
         default="{templated_validation_var}",

--- a/var/ramble/repos/builtin/applications/maxtext/application.py
+++ b/var/ramble/repos/builtin/applications/maxtext/application.py
@@ -109,18 +109,19 @@ class Maxtext(ExecutableApplication):
     )
 
     # Pyxis/Enroot parameters
-    workload_variable(
-        "maxtext_mount",
-        default="{maxtext_path}:{maxtext_path}",
-        description="Container mount for maxtext root",
-        workloads=all_workloads,
-    )
-    workload_variable(
-        "container_mounts",
-        default="{maxtext_mount}",
-        description="All container mounts in a ramble variable",
-        workloads=all_workloads,
-    )
+    with when("+containerized"):
+        workload_variable(
+            "maxtext_mount",
+            default="{maxtext_path}:{maxtext_path}",
+            description="Container mount for maxtext root",
+            workloads=all_workloads,
+        )
+        workload_variable(
+            "container_mounts",
+            default="{maxtext_mount}",
+            description="All container mounts in a ramble variable",
+            workloads=all_workloads,
+        )
 
     log_str = os.path.join("{experiment_run_dir}", "metrics.out")
     float_or_sci_regex = r"[+-]?[0-9]+(?:\.[0-9]*(?:[eE][+-]?[0-9]+)?)?"

--- a/var/ramble/repos/builtin/applications/py-nemo-2/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo-2/application.py
@@ -75,19 +75,20 @@ class PyNemo2(BasePyNemo):
         workload_group="pretraining",
     )
 
-    workload_variable(
-        "results_mount",
-        environment_variable_name="NEMO_CONTAINER_MOUNTS",
-        default="{experiment_run_dir}:{experiment_run_dir}",
-        description="Container mount for results data",
-        workload_group="pretraining",
-    )
-    workload_variable(
-        "container_mounts",
-        default="{results_mount}",
-        description="All container mounts in a ramble variable",
-        workload_group="pretraining",
-    )
+    with when("+containerized"):
+        workload_variable(
+            "results_mount",
+            environment_variable_name="NEMO_CONTAINER_MOUNTS",
+            default="{experiment_run_dir}:{experiment_run_dir}",
+            description="Container mount for results data",
+            workload_group="pretraining",
+        )
+        workload_variable(
+            "container_mounts",
+            default="{results_mount}",
+            description="All container mounts in a ramble variable",
+            workload_group="pretraining",
+        )
 
     register_phase(
         "copy_config", pipeline="setup", run_after=["make_experiments"]

--- a/var/ramble/repos/builtin/applications/py-nemo/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo/application.py
@@ -135,33 +135,34 @@ class PyNemo(BasePyNemo):
         workload_group="pretraining",
     )
 
-    workload_variable(
-        "logs_mount",
-        default="{exp_manager.explicit_log_dir}:{exp_manager.explicit_log_dir}",
-        description="Container mount for results data",
-        workload_group="pretraining",
-    )
+    with when("+containerized"):
+        workload_variable(
+            "logs_mount",
+            default="{exp_manager.explicit_log_dir}:{exp_manager.explicit_log_dir}",
+            description="Container mount for results data",
+            workload_group="pretraining",
+        )
 
-    workload_variable(
-        "results_mount",
-        default="{experiment_run_dir}:{experiment_run_dir}",
-        description="Container mount for results data",
-        workload_group="pretraining",
-    )
+        workload_variable(
+            "results_mount",
+            default="{experiment_run_dir}:{experiment_run_dir}",
+            description="Container mount for results data",
+            workload_group="pretraining",
+        )
 
-    environment_variable(
-        "NEMO_CONTAINER_MOUNTS",
-        value="{logs_mount},{results_mount}",
-        description="All container mounts in an environment variable",
-        workload_group="pretraining",
-    )
+        environment_variable(
+            "NEMO_CONTAINER_MOUNTS",
+            value="{logs_mount},{results_mount}",
+            description="All container mounts in an environment variable",
+            workload_group="pretraining",
+        )
 
-    workload_variable(
-        "container_mounts",
-        default="{logs_mount},{results_mount}",
-        description="All container mounts in a ramble variable",
-        workload_group="pretraining",
-    )
+        workload_variable(
+            "container_mounts",
+            default="{logs_mount},{results_mount}",
+            description="All container mounts in a ramble variable",
+            workload_group="pretraining",
+        )
 
     # Run parameters
     workload_variable(

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -215,6 +215,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             default=0,
             description="Index of this experiment, in repeat space",
         )
+        self.object_variants.default_variant(
+            name=namespace.containerized,
+            default=False,
+            description="Whether this experiment is run inside a container",
+        )
 
         self._vars_are_expanded = False
         self.expander = None

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -20,6 +20,7 @@ from ramble.language.workflow_manager_language import (
     workflow_manager_variable,
 )
 from ramble.util.naming import NS_SEPARATOR
+from ramble.workspace import namespace
 
 ObjectMixin = ramble.repository.get_base_class("object-mixin")
 
@@ -35,6 +36,7 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
         "setup",
         "execute",
     ]
+    is_containerized = False
 
     workflow_manager_variable(
         "workflow_banner",
@@ -95,6 +97,15 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
         """Set a reference to the associated app_inst"""
         self.app_inst = app_inst
         self.clear_variant_cache()
+
+        if (
+            self.is_containerized
+            and namespace.containerized not in app_inst.variants
+        ):
+            app_inst.object_variants.experiment_variant(
+                namespace.containerized, True
+            )
+            app_inst.clear_variant_cache()
 
     @abc.abstractmethod
     def get_status(self, workspace):

--- a/var/ramble/repos/builtin/workflow_managers/gke-mpi/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/gke-mpi/workflow_manager.py
@@ -24,6 +24,8 @@ class GkeMpi(WorkflowManagerBase):
 
     tags("workflow", "gke", "mpi")
 
+    is_containerized = True
+
     workflow_manager_variable(
         name="job_name",
         default="{application_name}-{workload_name}-{experiment_name}",

--- a/var/ramble/repos/builtin/workflow_managers/slurm-pyxis/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm-pyxis/workflow_manager.py
@@ -19,6 +19,8 @@ class SlurmPyxis(SlurmBase):
 
     tags("workflow", "slurm", "pyxis")
 
+    is_containerized = True
+
     workflow_manager_variable(
         name="container_path",
         default="",


### PR DESCRIPTION
This defines a standard variant +containerized and enables it for the relevant workflow managers. Apps can use this for conditional vars: 

eg
```
+    with when("+containerized"):
+        workload_variable(
+            "container_mounts",
+            default="{maxtext_mount}",
+            description="All container mounts in a ramble variable",
+            workloads=all_workloads,
+        )
```

The most important thing to review here is the use of `is_containerized` to enable it in the workflow manager classes, as it's kind of like a silent extension to the workflow manager language 