### PR TITLE
allow ramble to generate an empty env for injection

### DIFF
--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -397,6 +397,7 @@ class SoftwareEnvironment:
         self._packages: List[SoftwarePackage] = []
         self._environment_type = "Base"
         self._used = False
+        self.auto_constructed = False
 
     @property
     def is_used(self):
@@ -635,6 +636,7 @@ class TemplateEnvironment(SoftwareEnvironment):
         pm_name = package_manager.name
 
         new_env = RenderedEnvironment(name, package_manager)
+        new_env.auto_constructed = self.auto_constructed
 
         # Stores a mapping from rendered package name to template.
         # This helps with more efficient env package matching and
@@ -1069,10 +1071,33 @@ class SoftwareEnvironments:
                     return rendered_env
 
         if require:
-            raise RambleSoftwareEnvironmentError(
-                f"No defined environment matches required name {env_name}"
+            new_env_tmpl = TemplateEnvironment(env_name)
+            new_env_tmpl.auto_constructed = True
+            self._environment_templates[env_name] = new_env_tmpl
+            expander.flush_used_variable_stage()
+            expander.merge_used_variable_stage()
+            rendered_env = new_env_tmpl.render_environment(
+                expander, self._package_templates, self._rendered_packages, package_manager
             )
+            new_env_tmpl.add_rendered_environment(
+                rendered_env, self._rendered_environments, self._rendered_packages, pm_name
+            )
+            self.define_compiler_packages(rendered_env, expander)
+            self._check_environment(rendered_env)
+            return rendered_env
         return None
+
+    def check_all_environments(self):
+        """Check all rendered environments for issues after they have been fully set up"""
+        for pm_name, envs in self._rendered_environments.items():
+            for env in envs.values():
+                if getattr(env, "auto_constructed", False) and len(env._packages) == 0:
+                    logger.warn(
+                        f"Software environment '{env.name}' was auto-constructed "
+                        f"for package manager '{pm_name}' and contains no packages. "
+                        "If this was not intended, please define the environment "
+                        "or packages in your configuration."
+                    )
 
 
 class RambleSoftwareEnvironmentError(ramble.error.RambleError):

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -422,3 +422,42 @@ def test_is_used_property(request, mutable_mock_workspace_path):
         assert rendered_pkg.is_used is True
         assert env_template.is_used is True
         assert pkg_template.is_used is True
+
+
+def test_undefined_environment_auto_construction(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+    workspace("create", ws_name)
+
+    with ramble.workspace.read(ws_name) as ws:
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        assert "completely-undefined-env" not in software_environments._environment_templates
+
+        variables = {}
+        env_expander = ramble.expander.Expander(variables, None)
+        rendered_env = software_environments.render_environment(
+            "completely-undefined-env", env_expander, _get_package_manager()
+        )
+        assert rendered_env.name == "completely-undefined-env"
+        assert "completely-undefined-env" in software_environments._environment_templates
+        assert len(rendered_env._packages) == 0
+
+
+def test_check_all_environments_warning(request, mutable_mock_workspace_path, capsys):
+    ws_name = request.node.name
+    workspace("create", ws_name)
+
+    with ramble.workspace.read(ws_name) as ws:
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        variables = {}
+        env_expander = ramble.expander.Expander(variables, None)
+        _ = software_environments.render_environment(
+            "completely-undefined-env", env_expander, _get_package_manager()
+        )
+
+        software_environments.check_all_environments()
+        captured = capsys.readouterr()
+        assert (
+            "Software environment 'completely-undefined-env' was auto-constructed" in captured.err
+        )

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -885,6 +885,9 @@ ramble:
 
         experiment_set.build_experiment_chains()
 
+        if self.software_environments is not None:
+            self.software_environments.check_all_environments()
+
         return experiment_set
 
     def all_applications(self):


### PR DESCRIPTION
Previously the user has to specify an env explicitly, even if it was allowed to be empty.

```
    ==> Error: No defined environment matches required name gromacs
```

Ramble now creates a default empty env and allows packages to be injected into it as required. Detecting missing required packages still works the same