### PR TITLE
allow defined packages to take precendece over injected

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/software_spec_injection.py
+++ b/lib/ramble/ramble/test/end_to_end/software_spec_injection.py
@@ -243,3 +243,56 @@ def test_software_spec_compiler_injection_works(
         info_out = workspace("info", "--software", global_args=global_args)
 
         assert "injected_compiler" in info_out
+
+
+def test_conflict_resolution_inject_if_missing(
+    mock_modifiers, ensure_spack_runner, make_workspace_from_config
+):
+    test_config = """
+ramble:
+  variants:
+    package_manager: spack
+    implicit_compiler: True
+  variables:
+    mpi_command: 'mpirun -n {n_ranks}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    gromacs:
+      workloads:
+        water_bare:
+          experiments:
+            test_exp:
+              variables:
+                n_nodes: '1'
+                n_ranks: '1'
+              modifiers:
+                - name: spack-mod
+  software:
+    environments:
+      gromacs:
+        packages:
+          - my_custom_package
+    packages:
+      my_custom_package:
+        pkg_spec: missing_package@2.0
+"""
+    ws, ws_name = make_workspace_from_config(test_config)
+    global_args = ["-w", ws_name]
+
+    # Concretize the workspace. If the conflict resolution is correct,
+    # it should NOT concretize/inject `missing_mod_package` because
+    # `my_custom_package` (which defines `missing_package`) is already defined.
+    workspace("concretize", global_args=global_args)
+
+    info_output = workspace("info", "--software", global_args=global_args)
+
+    # `missing_mod_package` should NOT be in the environment.
+    assert "missing_mod_package" not in info_output
+    assert "missing_package@1.1" not in info_output
+
+    # `my_custom_package` (which is `missing_package@2.0`) should be in the environment.
+    assert "my_custom_package" in info_output
+    assert "missing_package@2.0" in info_output

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1539,37 +1539,71 @@ ramble:
                 if namespace.packages in environments_dict[env_name]:
                     app_packages = environments_dict[env_name][namespace.packages].copy()
 
+            defined_pm_packages = set()
+            for pkg in app_packages:
+                if pkg in packages_dict:
+                    pkg_spec = None
+                    for key in packages_dict[pkg]:
+                        if key == "pkg_spec" or key.endswith("_pkg_spec"):
+                            pkg_spec = packages_dict[pkg][key]
+                            break
+                    if pkg_spec:
+                        pm_package_name = app_inst.package_manager.package_name_from_spec(pkg_spec)
+                        if pm_package_name:
+                            defined_pm_packages.add(pm_package_name)
+
             software_packages = app_inst.package_manager.get_experiment_specs(
                 app_inst=app_inst, prefixed=force_prefix
             )
-            for spec_name, definitions in software_packages.items():
-                for info in definitions:
-                    logger.debug(f"    Found spec: {spec_name}")
-                    if (
-                        not quiet
-                        and spec_name in packages_dict
-                        and info.conflict_dict(packages_dict[spec_name])
-                    ):
-                        logger.debug(f"  Spec 1: {str(info)}")
-                        logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
-                        raise RambleConflictingDefinitionError(
-                            f"Package {spec_name} would be defined in multiple " "conflicting ways"
+            specs_to_process = [
+                (spec_name, info)
+                for spec_name, definitions in software_packages.items()
+                for info in definitions
+            ]
+
+            # Sort specs: inject_if_missing=False first
+            specs_to_process.sort(key=lambda x: x[1].inject_if_missing)
+
+            for spec_name, info in specs_to_process:
+                logger.debug(f"    Found spec: {spec_name}")
+                pm_package_name = app_inst.package_manager.package_name_from_spec(info.pkg_spec)
+
+                if info.inject_if_missing:
+                    if pm_package_name in defined_pm_packages:
+                        logger.debug(
+                            f"    Skipping inject_if_missing spec {spec_name} "
+                            f"because package {pm_package_name} is already defined."
                         )
+                        continue
 
-                    if spec_name not in packages_dict or (
-                        force and spec_name not in newly_created_packages
-                    ):
-                        packages_dict[spec_name] = syaml.syaml_dict()
+                if (
+                    not quiet
+                    and spec_name in packages_dict
+                    and info.conflict_dict(packages_dict[spec_name])
+                ):
+                    logger.debug(f"  Spec 1: {str(info)}")
+                    logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
+                    raise RambleConflictingDefinitionError(
+                        f"Package {spec_name} would be defined in multiple " "conflicting ways"
+                    )
 
-                    # Check for usage of compilers
-                    expanded_compiler = app_inst.expander.expand_var(info.compiler)
-                    if expanded_compiler in compiler_packages:
-                        compiler_packages[expanded_compiler] = True
+                if spec_name not in packages_dict or (
+                    force and spec_name not in newly_created_packages
+                ):
+                    packages_dict[spec_name] = syaml.syaml_dict()
 
-                    packages_dict[spec_name].update(info.to_dict(apply_prefix=force_prefix))
+                # Check for usage of compilers
+                expanded_compiler = app_inst.expander.expand_var(info.compiler)
+                if expanded_compiler in compiler_packages:
+                    compiler_packages[expanded_compiler] = True
 
-                    if spec_name not in app_packages:
-                        app_packages.append(spec_name)
+                packages_dict[spec_name].update(info.to_dict(apply_prefix=force_prefix))
+
+                if spec_name not in app_packages:
+                    app_packages.append(spec_name)
+
+                if pm_package_name:
+                    defined_pm_packages.add(pm_package_name)
 
             if app_packages:
                 if env_name not in environments_dict:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1541,11 +1541,11 @@ ramble:
 
             defined_pm_packages = set()
             for pkg in app_packages:
-                if pkg in packages_dict:
+                if pkg in packages_dict and isinstance(packages_dict[pkg], dict):
                     pkg_spec = None
-                    for key in packages_dict[pkg]:
+                    for key, val in packages_dict[pkg].items():
                         if key == "pkg_spec" or key.endswith("_pkg_spec"):
-                            pkg_spec = packages_dict[pkg][key]
+                            pkg_spec = val
                             break
                     if pkg_spec:
                         pm_package_name = app_inst.package_manager.package_name_from_spec(pkg_spec)
@@ -1566,10 +1566,14 @@ ramble:
 
             for spec_name, info in specs_to_process:
                 logger.debug(f"    Found spec: {spec_name}")
-                pm_package_name = app_inst.package_manager.package_name_from_spec(info.pkg_spec)
+                pm_package_name = None
+                if info.pkg_spec:
+                    pm_package_name = app_inst.package_manager.package_name_from_spec(
+                        info.pkg_spec
+                    )
 
                 if info.inject_if_missing:
-                    if pm_package_name in defined_pm_packages:
+                    if pm_package_name and pm_package_name in defined_pm_packages:
                         logger.debug(
                             f"    Skipping inject_if_missing spec {spec_name} "
                             f"because package {pm_package_name} is already defined."

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -259,17 +259,25 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
             for pkg_spec in software_envs.package_specs_for_environment(
                 software_env
             ):
-                env_packages.add(self.package_name_from_spec(pkg_spec))
+                if pkg_spec:
+                    pkg_name = self.package_name_from_spec(pkg_spec)
+                    if pkg_name:
+                        env_packages.add(pkg_name)
 
             for _, obj in self.app_inst.objects():
                 required_compilers = set()
                 # Inject any specs that need to be injected.
                 for specs in obj.software_specs.values():
                     for spec in specs:
-                        pkg_name = self.package_name_from_spec(spec.pkg_spec)
+                        pkg_name = None
+                        if spec.pkg_spec:
+                            pkg_name = self.package_name_from_spec(
+                                spec.pkg_spec
+                            )
 
                         if (
                             spec.inject_if_missing
+                            and pkg_name
                             and pkg_name not in env_packages
                             and self.app_inst.expander.satisfies(
                                 spec.when,


### PR DESCRIPTION
if a package is defined with the same name (the spack package name, not the ramble package name) the defined one should take precedence.