### PR TITLE
Add `allow_external` arg when requiring utilities

### DIFF
--- a/lib/ramble/docs/dev_guides/utility_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/utility_dev_guide.rst
@@ -107,11 +107,11 @@ If an object requiring this utility provides a `min_version` or `max_version`, R
 ``requires_utility``
 --------------------
 
-Other objects (like Applications or Modifiers) can require a utility and optionally specify a minimum or maximum version using the ``requires_utility`` directive.
+Other objects (like Applications or Modifiers) can require a utility and optionally specify a minimum or maximum version using the ``requires_utility`` directive. You can also specify if the utility can be provided by the system with the ``allow_external`` boolean flag (defaults to ``True``).
 
 .. code-block:: python
 
-    requires_utility("cmake", min_version="3.20.0", max_version="3.30.0")
+    requires_utility("cmake", min_version="3.20.0", max_version="3.30.0", allow_external=True)
 
 Environment Modifications
 =========================

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -1060,7 +1060,14 @@ def requires_utility(
             obj.required_utilities[when_key] = {}
 
         obj.required_utilities[when_key][name] = kwargs.copy()
-        obj.required_utilities[when_key][name]["allow_external"] = allow_external
+
+        parsed_allow_external = True
+        if isinstance(allow_external, str) and allow_external.lower() == "false":
+            parsed_allow_external = False
+        elif not isinstance(allow_external, str):
+            parsed_allow_external = bool(allow_external)
+
+        obj.required_utilities[when_key][name]["allow_external"] = parsed_allow_external
         obj.required_utilities[when_key][name]["when"] = when_list
 
     return _define_requires_utility

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -1037,12 +1037,14 @@ def register_validator(
 def requires_utility(
     name: str,
     when=None,
+    allow_external: bool = True,
     **kwargs,
 ):
     """Directive to declare an external dependency.
 
     Args:
         name: Name of the external dependency required (e.g. spack)
+        allow_external: Whether or not the dependency can be satisfied by a system installation
         when: List of when conditions to apply to directive
         **kwargs: Optional configuration overrides for the dependency (e.g. version). Also
             supports ``min_version`` and ``max_version`` to constrain the required version.
@@ -1058,6 +1060,7 @@ def requires_utility(
             obj.required_utilities[when_key] = {}
 
         obj.required_utilities[when_key][name] = kwargs.copy()
+        obj.required_utilities[when_key][name]["allow_external"] = allow_external
         obj.required_utilities[when_key][name]["when"] = when_list
 
     return _define_requires_utility

--- a/lib/ramble/ramble/test/language/test_requires_utility.py
+++ b/lib/ramble/ramble/test/language/test_requires_utility.py
@@ -9,8 +9,13 @@
 import ramble.language.shared_language
 from ramble.language.language_base import DirectiveMeta
 
+# Save and clear the global directives queue to isolate from other tests
+_saved_queue = DirectiveMeta._directives_to_be_executed.copy()
+DirectiveMeta._directives_to_be_executed = []
+
 
 class MockObject(metaclass=DirectiveMeta):
+    name = "mock_obj"
     __module__ = "ramble.app"
     required_utilities: dict = {}
 
@@ -20,6 +25,41 @@ class MockObject(metaclass=DirectiveMeta):
         commit="v1.0",
         when="mock_when=True",
     )
+
+    ramble.language.shared_language.requires_utility(
+        name="my_ext_dep_allow",
+        git="https://github.com/my/ext_dep.git",
+        commit="v1.0",
+        when="mock_when=True",
+        allow_external=True,
+    )
+
+    ramble.language.shared_language.requires_utility(
+        name="my_ext_dep_no_allow",
+        git="https://github.com/my/ext_dep.git",
+        commit="v1.0",
+        when="mock_when=True",
+        allow_external=False,
+    )
+
+    ramble.language.shared_language.requires_utility(
+        name="my_ext_dep_allow_str",
+        git="https://github.com/my/ext_dep.git",
+        commit="v1.0",
+        when="mock_when=True",
+        allow_external="True",
+    )
+
+    ramble.language.shared_language.requires_utility(
+        name="my_ext_dep_no_allow_str",
+        git="https://github.com/my/ext_dep.git",
+        commit="v1.0",
+        when="mock_when=True",
+        allow_external="False",
+    )
+
+
+DirectiveMeta._directives_to_be_executed = _saved_queue
 
 
 def test_requires_utility_directive_parsing():
@@ -33,3 +73,16 @@ def test_requires_utility_directive_parsing():
     assert ext_dep["git"] == "https://github.com/my/ext_dep.git"
     assert ext_dep["commit"] == "v1.0"
     assert ext_dep["when"] == when_list
+    assert ext_dep["allow_external"] is True  # Default is True
+
+    ext_dep_allow = obj.required_utilities[when_key]["my_ext_dep_allow"]
+    assert ext_dep_allow["allow_external"] is True
+
+    ext_dep_no_allow = obj.required_utilities[when_key]["my_ext_dep_no_allow"]
+    assert ext_dep_no_allow["allow_external"] is False
+
+    ext_dep_allow_str = obj.required_utilities[when_key]["my_ext_dep_allow_str"]
+    assert ext_dep_allow_str["allow_external"] is True
+
+    ext_dep_no_allow_str = obj.required_utilities[when_key]["my_ext_dep_no_allow_str"]
+    assert ext_dep_no_allow_str["allow_external"] is False

--- a/lib/ramble/ramble/test/package_manager_functionality/test_spack_lightweight.py
+++ b/lib/ramble/ramble/test/package_manager_functionality/test_spack_lightweight.py
@@ -1,0 +1,64 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import importlib.util
+import os
+
+import ramble.util.command_runner
+
+
+def test_spack_lightweight_runner_error(monkeypatch):
+    """Test that SpackRunner handles RunnerError when spack is not found"""
+    # We want to force a RunnerError in SpackRunner.__init__
+    # The error comes from CommandRunner when the command is not in path.
+    orig_init = ramble.util.command_runner.CommandRunner.__init__
+
+    def mock_init(self, name=None, command=None, **kwargs):
+        if command == "spack" or name == "spack":
+            raise ramble.util.command_runner.RunnerError("Command spack not found")
+        orig_init(self, name=name, command=command, **kwargs)
+
+    monkeypatch.setattr(ramble.util.command_runner.CommandRunner, "__init__", mock_init)
+
+    spec = importlib.util.spec_from_file_location(
+        "spack_lightweight",
+        "var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    SpackRunner = module.SpackRunner
+
+    runner = SpackRunner(shell="bash", dry_run=False, env=None)
+
+    assert runner.spack is None
+    assert runner.installer is None
+    assert runner.concretizer is None
+    assert runner.spack_dir == os.path.join("missing", "path")
+    assert runner.get_version() is None
+
+    runner.env_path = "/tmp/fake/env"
+    runner.activate()
+    assert runner.active is True
+    runner.deactivate()
+    assert runner.active is False
+
+    runner_csh = SpackRunner(shell="csh", dry_run=False, env=None)
+    assert runner_csh.shell == "csh"
+    assert runner_csh.spack is None
+
+    runner_fish = SpackRunner(shell="fish", dry_run=False, env=None)
+    assert runner_fish.shell == "fish"
+    assert runner_fish.spack is None
+
+    runner_tcsh = SpackRunner(shell="tcsh", dry_run=False, env=None)
+    assert runner_tcsh.shell == "tcsh"
+    assert runner_tcsh.spack is None
+
+    runner_unknown = SpackRunner(shell="unknown", dry_run=False, env=None)
+    assert runner_unknown.shell == "unknown"
+    assert runner_unknown.spack is None

--- a/lib/ramble/ramble/test/test_base_classes_extra.py
+++ b/lib/ramble/ramble/test/test_base_classes_extra.py
@@ -193,7 +193,9 @@ def test_application_base_bootstrap_utilities_is_available_true(
     with ws:
         setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
         app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
-        app_inst.required_utilities = {frozenset([]): {"spack": {"git": "mygit"}}}
+        app_inst.required_utilities = {
+            frozenset([]): {"spack": {"git": "mygit", "allow_external": "True"}}
+        }
         monkeypatch.setattr(
             shutil, "which", lambda cmd, **kwargs: "/path/to/spack" if cmd == "spack" else None
         )
@@ -241,6 +243,71 @@ def test_application_base_bootstrap_utilities_is_bootstrappable_false(
         with pytest.raises(SystemExit):
             setup_pipeline.run()
         # Custom Error should have been logged
+
+
+def test_application_base_bootstrap_utilities_allow_external_false(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws = ramble.workspace.create("test_allow_ext_false")
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write("""ramble:
+  config:
+    bootstrap_utilities: True
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+  utilities:
+    spack:
+      git: mygit
+""")
+    ws._re_read()
+    filters = ramble.filters.Filters()
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {
+            frozenset([]): {"spack": {"git": "mygit", "allow_external": "False"}}
+        }
+        UtilityBase = ramble.repository.get_base_class("utility-base")
+
+        def mock_is_available(*args, **kwargs):
+            raise Exception("is_available should not be called when allow_external=False")
+
+        monkeypatch.setattr(UtilityBase, "is_available", mock_is_available)
+
+        ws.dry_run = False
+
+        class MockStage:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def set_subdir(self, subdir):
+                pass
+
+            def fetch(self):
+                pass
+
+            def expand_archive(self):
+                pass
+
+        monkeypatch.setattr(ramble.stage, "InputStage", MockStage)
+        monkeypatch.setattr(UtilityBase, "validate_versions", lambda *a, **k: True)
+
+        setup_pipeline.run()
+    assert hasattr(app_inst, "_bootstrapped_utility_paths")
+    assert "spack" in app_inst._bootstrapped_utility_paths
 
 
 def test_application_base_bootstrap_utilities_success(
@@ -321,3 +388,45 @@ def test_spack_utility_is_available_version_checking(
     assert spack.is_available(ws, min_version="0.20.0", max_version="0.25.0") is True
     assert spack.is_available(ws, min_version="0.23.0") is False
     assert spack.is_available(ws, max_version="0.21.0") is False
+
+
+def test_application_base_bootstrap_utilities_allow_external_false_bool(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws = ramble.workspace.create("test_allow_ext_false_bool")
+    import os
+
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write("""ramble:
+  config:
+    bootstrap_utilities: True
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+  utilities:
+    spack:
+      git: mygit
+""")
+    ws._re_read()
+    filters = ramble.filters.Filters()
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {
+            frozenset([]): {"spack": {"git": "mygit", "allow_external": False}}
+        }
+        UtilityBase = ramble.repository.get_base_class("utility-base")
+
+        def mock_is_available(*args, **kwargs):
+            raise Exception("is_available should not be called when allow_external=False")
+
+        monkeypatch.setattr(UtilityBase, "is_available", mock_is_available)
+
+        ws.dry_run = False
+        app_inst._bootstrap_utilities(ws)

--- a/lib/ramble/ramble/test/test_base_classes_extra.py
+++ b/lib/ramble/ramble/test/test_base_classes_extra.py
@@ -176,8 +176,6 @@ def test_application_base_bootstrap_utilities_is_available_true(
         f.write("""ramble:
   config:
     bootstrap_utilities: True
-  variables:
-    use_system_spack: True
   applications:
     hostname:
       workloads:
@@ -308,13 +306,7 @@ def test_spack_utility_is_available_version_checking(
     mutable_config, mutable_mock_workspace_path, monkeypatch
 ):
     ws = ramble.workspace.create("test_spack_ver")
-    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
-    with open(ws.config_file_path, "w", encoding="utf-8") as f:
-        f.write("""ramble:
-  variables:
-    use_system_spack: True
-""")
-    ws._re_read()
+
     spack = Spack("/tmp/dummy")
     monkeypatch.setattr(
         shutil, "which", lambda cmd, **kwargs: "/path/to/spack" if cmd == "spack" else None
@@ -326,21 +318,6 @@ def test_spack_utility_is_available_version_checking(
         returncode = 0
 
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: MockResult())
-
-    # When use_system_spack is True, regardless of version, do not bootstrap
-    # a new spack (return True if installed)
-    assert spack.is_available(ws, min_version="0.20.0", max_version="0.25.0") is True
-    assert spack.is_available(ws, min_version="0.23.0") is True
-    assert spack.is_available(ws, max_version="0.21.0") is True
-
-    # When use_system_spack is False, only return True (avoid bootstrap) if
-    # already-installed spack has right version
-    with open(ws.config_file_path, "w", encoding="utf-8") as f:
-        f.write("""ramble:
-  variables:
-    use_system_spack: False
-""")
-    ws._re_read()
     assert spack.is_available(ws, min_version="0.20.0", max_version="0.25.0") is True
     assert spack.is_available(ws, min_version="0.23.0") is False
     assert spack.is_available(ws, max_version="0.21.0") is False

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -2691,18 +2691,35 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                             ext_dep_paths[ext_dep_name] = "system"
                             continue
 
-                        if hasattr(
-                            ext_dep_inst, "is_available"
-                        ) and ext_dep_inst.is_available(
-                            workspace,
-                            min_version=min_version,
-                            max_version=max_version,
-                        ):
-                            logger.debug(
-                                f"External dependency {ext_dep_name} is already available in the environment, skipping fetch."
+                        allow_external = fetch_kwargs.pop(
+                            "allow_external", True
+                        )
+
+                        if isinstance(allow_external, str):
+                            allow_external = allow_external.lower() == "true"
+                        else:
+                            allow_external = bool(allow_external)
+
+                        if allow_external:
+                            if hasattr(
+                                ext_dep_inst, "is_available"
+                            ) and ext_dep_inst.is_available(
+                                workspace,
+                                min_version=min_version,
+                                max_version=max_version,
+                            ):
+                                logger.debug(
+                                    f"External dependency {ext_dep_name} is already available in the environment, skipping fetch."
+                                )
+                                ext_dep_paths[ext_dep_name] = "system"
+                                continue
+                            logger.msg(
+                                f"External dependency {ext_dep_name} is not available in the environment. Bootstrapping a new version."
                             )
-                            ext_dep_paths[ext_dep_name] = "system"
-                            continue
+                        else:
+                            logger.msg(
+                                f"External dependency {ext_dep_name} is not allowed to be provided externally. Bootstrapping a new version."
+                            )
 
                         is_bootstrappable = True
                         if hasattr(ext_dep_inst, "bootstrappable"):

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -799,6 +799,7 @@ class SpackRunner(CommandRunner):
                 os.path.dirname(self.spack.exe[0])
             )
         except RunnerError:
+            self.shell = shell
             self.spack = None
             self.installer = None
             self.concretizer = None
@@ -810,6 +811,8 @@ class SpackRunner(CommandRunner):
             script = "setup-env.csh"
         elif self.shell == "fish":
             script = "setup-env.fish"
+        else:
+            script = "setup-env.sh"
         self.source_script = os.path.join(
             self.spack_dir, "share", "spack", script
         )
@@ -1106,7 +1109,7 @@ class SpackRunner(CommandRunner):
             del self.spack.default_env[self.env_key]
             del self.installer.default_env[self.env_key]
             del self.concretizer.default_env[self.env_key]
-            self.active = False
+        self.active = False
 
     def _check_active(self):
         if not self.env_path:

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -17,6 +17,7 @@ import tempfile
 import llnl.util.filesystem as fs
 
 from ramble.pkgmankit import *
+from ramble.util.command_runner import RunnerError
 from ramble.util.logger import logger
 
 import spack.util.spack_yaml as syaml
@@ -764,24 +765,44 @@ class SpackRunner(CommandRunner):
         Ensure spack is found in the path, and setup some default variables.
         """
 
-        super().__init__(
-            name="spack",
-            command="spack",
-            shell=shell,
-            dry_run=dry_run,
-            env=env,
-        )
-        self.spack = self.command
+        try:
+            super().__init__(
+                name="spack",
+                command="spack",
+                shell=shell,
+                dry_run=dry_run,
+                env=env,
+            )
 
-        # Add default arguments to spack command.
-        # This allows us to inject custom config scope dirs
-        # primarily for unit testing.
-        global_args = ramble.config.get(f"{self.global_config_name}:flags")
-        if global_args is not None:
-            for arg in shlex.split(global_args):
-                self.spack.add_default_arg(arg)
+            self.spack = self.command
+            self.installer = self.spack.copy()
+            self.installer.add_default_prefix(
+                ramble.config.get(f"{self.install_config_name}:prefix")
+            )
+            self.installer.add_default_arg("install")
 
-        self.spack_dir = os.path.dirname(os.path.dirname(self.spack.exe[0]))
+            self.concretizer = self.spack.copy()
+            self.concretizer.add_default_prefix(
+                ramble.config.get(f"{self.concretize_config_name}:prefix")
+            )
+            self.concretizer.add_default_arg("concretize")
+
+            # Add default arguments to spack command.
+            # This allows us to inject custom config scope dirs
+            # primarily for unit testing.
+            global_args = ramble.config.get(f"{self.global_config_name}:flags")
+            if global_args is not None:
+                for arg in shlex.split(global_args):
+                    self.spack.add_default_arg(arg)
+
+            self.spack_dir = os.path.dirname(
+                os.path.dirname(self.spack.exe[0])
+            )
+        except RunnerError:
+            self.spack = None
+            self.installer = None
+            self.concretizer = None
+            self.spack_dir = os.path.join("missing", "path")
 
         if self.shell == "bash":
             script = "setup-env.sh"
@@ -808,18 +829,6 @@ class SpackRunner(CommandRunner):
         self.configs_applied = False
         self.env_contents = []
 
-        self.installer = self.spack.copy()
-        self.installer.add_default_prefix(
-            ramble.config.get(f"{self.install_config_name}:prefix")
-        )
-        self.installer.add_default_arg("install")
-
-        self.concretizer = self.spack.copy()
-        self.concretizer.add_default_prefix(
-            ramble.config.get(f"{self.concretize_config_name}:prefix")
-        )
-        self.concretizer.add_default_arg("concretize")
-
     def get_spack_python(self):
         if self.dry_run:
             return self.bs_python
@@ -834,20 +843,22 @@ class SpackRunner(CommandRunner):
 
         from ramble.util.version import get_git_hash
 
-        version_spec = importlib.util.spec_from_file_location(
-            "spack_version",
-            os.path.join(
-                self.spack_dir, "lib", "spack", "spack", "__init__.py"
-            ),
-        )
-        version_mod = importlib.util.module_from_spec(version_spec)
-        version_spec.loader.exec_module(version_mod)
+        spack_version = None
+        if self.spack:
+            version_spec = importlib.util.spec_from_file_location(
+                "spack_version",
+                os.path.join(
+                    self.spack_dir, "lib", "spack", "spack", "__init__.py"
+                ),
+            )
+            version_mod = importlib.util.module_from_spec(version_spec)
+            version_spec.loader.exec_module(version_mod)
 
-        spack_version = version_mod.spack_version
-        spack_hash = get_git_hash(path=self.spack_dir)
+            spack_version = version_mod.spack_version
+            spack_hash = get_git_hash(path=self.spack_dir)
 
-        if spack_hash:
-            spack_version += f" ({spack_hash})"
+            if spack_hash:
+                spack_version += f" ({spack_hash})"
 
         return spack_version
 
@@ -1071,9 +1082,10 @@ class SpackRunner(CommandRunner):
                 "Environment runner has no path configured"
             )
 
-        self.spack.add_default_env(self.env_key, self.env_path)
-        self.installer.add_default_env(self.env_key, self.env_path)
-        self.concretizer.add_default_env(self.env_key, self.env_path)
+        if self.spack:
+            self.spack.add_default_env(self.env_key, self.env_path)
+            self.installer.add_default_env(self.env_key, self.env_path)
+            self.concretizer.add_default_env(self.env_key, self.env_path)
 
         self.active = True
 
@@ -1086,7 +1098,11 @@ class SpackRunner(CommandRunner):
                 "Environment runner has no path configured"
             )
 
-        if self.active and self.env_key in self.spack.default_env:
+        if (
+            self.spack
+            and self.active
+            and self.env_key in self.spack.default_env
+        ):
             del self.spack.default_env[self.env_key]
             del self.installer.default_env[self.env_key]
             del self.concretizer.default_env[self.env_key]

--- a/var/ramble/repos/builtin/utilities/spack/utility.py
+++ b/var/ramble/repos/builtin/utilities/spack/utility.py
@@ -35,7 +35,7 @@ class Spack(UtilityBase):
     )
     variable(
         "spack_version",
-        default="v0.22.0",
+        default="v1.2.2",
         description="Version of spack to fetch",
     )
 

--- a/var/ramble/repos/builtin/utilities/spack/utility.py
+++ b/var/ramble/repos/builtin/utilities/spack/utility.py
@@ -57,18 +57,3 @@ class Spack(UtilityBase):
     def install(self, workspace):
         # E.g., make, configure, etc.
         logger.debug(f"Executing install phase for {self.name}")
-
-    def is_available(self, workspace, min_version=None, max_version=None):
-        """Check if spack is available in the user's environment."""
-        # Only return True if the user explicitly opted into using the system spack
-        # via a workspace variable, otherwise we should bootstrap the requested version.
-        ws_vars = (
-            workspace._get_workspace_dict()
-            .get("ramble", {})
-            .get("variables", {})
-        )
-        if ws_vars.get("use_system_spack", False):
-            return super().is_available(workspace)
-        return super().is_available(
-            workspace, min_version=min_version, max_version=max_version
-        )


### PR DESCRIPTION
This merge adds the `allow_external` arugment on the `requires_utility` directive. This can be used to allow (or disallow) experiments from using an external utilty. For example, this can be used to force experiments to always bootstrap an internal spack instead of allowing a user installed spack to be used.

Additionally, this merge fixes an issue when running some ramble commands without having spack in your path.