### PR TITLE
Ensure `<var> in <exp>` syntax works for chained experiment

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -991,10 +991,9 @@ class ExperimentSet:
             variable: Name of variable to look up
         """
 
-        if experiment not in self.experiments:
+        exp_app = self.get_experiment(experiment)
+        if not exp_app:
             return None
-
-        exp_app = self.experiments[experiment]
 
         return exp_app.expander.expand_var(variable)
 

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -1056,6 +1056,15 @@ def test_chained_experiments_populate_new_experiments(workspace_name):
         assert "basic.test_wl.series2_6.chain.1.basic.test_wl.test1" in exp_set.chained_experiments
         assert "basic.test_wl.test1" in exp_set.experiments
 
+        assert exp_set.get_var_from_experiment("basic.test_wl.series2_4", "{n_ranks}") == "4"
+        assert (
+            exp_set.get_var_from_experiment(
+                "basic.test_wl.series2_4.chain.0.basic.test_wl.test1", "{n_ranks}"
+            )
+            == "2"
+        )
+        assert exp_set.get_var_from_experiment("non_existent.exp.name", "{n_ranks}") is None
+
 
 def test_chained_experiment_has_correct_directory(workspace_name):
     workspace("create", workspace_name)


### PR DESCRIPTION
Previously the `get_var_from_experiment` only looks at `self.experiments`, such that chained_experiments are skipped.