### PR TITLE
allow parents to be queried by  `--where "'{experiment_status}' ==`

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -808,6 +808,10 @@ class ExperimentSet:
             else:
                 self.add_chained_experiment(app_inst.expander.experiment_name, app_inst)
 
+        for app_inst in rendered_instances:
+            if app_inst.repeats.is_repeat_base:
+                app_inst.read_status()
+
         for wl_name, stats in overall_wl_stats.items():
             if stats["passed_global"] > 0 and stats["processed"] == 0 and stats["dropped_wl"] > 0:
                 logger.warn(
@@ -906,6 +910,10 @@ class ExperimentSet:
         """Return the number of filtered experiments in this set"""
         return len(self.filtered_experiments(filters))
 
+    def clear_filter_cache(self):
+        """Clear the filtered experiments cache"""
+        self._filtered_experiments_cache.clear()
+
     def filtered_experiments(self, filters):
         """Return a filtered set of all experiments based on a logical expression
 
@@ -930,6 +938,9 @@ class ExperimentSet:
         filtered_list = []
         for exp, inst, idx in self.all_experiments():
             active = True
+
+            if inst.repeats.is_repeat_base:
+                inst.read_status()
 
             if filters.include_where:
                 for expression in filters.include_where:

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -319,6 +319,7 @@ class AnalyzePipeline(Pipeline):
 
     def _complete(self):
         super()._complete()
+        self._experiment_set.clear_filter_cache()
         # Calculate statistics for repeats and inject into base experiment results
         for _, app_inst, _ in self._experiment_set.filtered_experiments(self.filters):
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
@@ -11,6 +11,7 @@ import os
 import pytest
 
 from ramble.main import RambleCommand
+from ramble.util import json_util
 from ramble.util.foms import SummaryFoms
 
 # everything here uses the mock_workspace_path
@@ -85,3 +86,164 @@ ramble:
         assert "SUCCESS" not in data
         assert f"summary::{SummaryFoms.N_TOTAL.value}" not in data
         assert f"summary::{SummaryFoms.N_SUCCESS.value}" not in data
+
+
+def test_repeat_analyze_where_experiment_status(mock_applications, make_workspace_from_config):
+    # Test strict mode (default: repeat_success_strict is True)
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            test_exp:
+              n_repeats: 2
+              variables:
+                n_nodes: 1
+  software:
+    packages: {}
+    environments: {}
+"""
+    ws, ws_name = make_workspace_from_config(test_config)
+
+    workspace("setup", global_args=["-w", ws_name])
+    ramble_on(global_args=["-w", ws_name])
+
+    # Fail repeat child 1
+    result_path = os.path.join(
+        ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
+    )
+    with open(result_path, "w+", encoding="utf-8") as f:
+        f.write("")
+
+    # First analyze without filters so child statuses are recorded
+    workspace("analyze", "-f", "json", "text", global_args=["-w", ws_name])
+
+    # Now analyze filtering for FAILED
+    workspace(
+        "analyze",
+        "-f",
+        "json",
+        "text",
+        "--where",
+        "'{experiment_status}' == 'FAILED'",
+        global_args=["-w", ws_name],
+    )
+
+    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+        data = json_util.load(f)
+        exp_names = [exp["name"] for exp in data["experiments"]]
+        # In strict mode, since child 1 failed, both parent and child 1 must be present as FAILED
+        assert "basic.working_wl.test_exp" in exp_names
+        assert "basic.working_wl.test_exp.1" in exp_names
+        assert "basic.working_wl.test_exp.2" not in exp_names
+
+    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+        txt_data = f.read()
+        assert "Experiment basic.working_wl.test_exp figures of merit:" in txt_data
+        assert "Experiment basic.working_wl.test_exp.1 figures of merit:" in txt_data
+        assert "Experiment basic.working_wl.test_exp.2 figures of merit:" not in txt_data
+
+    # Now analyze filtering for SUCCESS
+    workspace(
+        "analyze",
+        "-f",
+        "json",
+        "text",
+        "--where",
+        "'{experiment_status}' == 'SUCCESS'",
+        global_args=["-w", ws_name],
+    )
+
+    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+        data = json_util.load(f)
+        exp_names = [exp["name"] for exp in data["experiments"]]
+        # In strict mode, parent is FAILED, so only child 2 is SUCCESS
+        assert "basic.working_wl.test_exp" not in exp_names
+        assert "basic.working_wl.test_exp.1" not in exp_names
+        assert "basic.working_wl.test_exp.2" in exp_names
+
+
+def test_repeat_analyze_where_experiment_status_loose(
+    mock_applications, make_workspace_from_config
+):
+    # Test loose mode (repeat_success_strict is False)
+    test_config = """
+ramble:
+  config:
+    repeat_success_strict: False
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            test_exp:
+              n_repeats: 2
+              variables:
+                n_nodes: 1
+  software:
+    packages: {}
+    environments: {}
+"""
+    ws, ws_name = make_workspace_from_config(test_config)
+
+    workspace("setup", global_args=["-w", ws_name])
+    ramble_on(global_args=["-w", ws_name])
+
+    # Fail repeat child 1
+    result_path = os.path.join(
+        ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
+    )
+    with open(result_path, "w+", encoding="utf-8") as f:
+        f.write("")
+
+    # First analyze without filters so child statuses are recorded
+    workspace("analyze", "-f", "json", "text", global_args=["-w", ws_name])
+
+    # In loose mode, child 2 succeeded, so parent is SUCCESS
+    workspace(
+        "analyze",
+        "-f",
+        "json",
+        "text",
+        "--where",
+        "'{experiment_status}' == 'SUCCESS'",
+        global_args=["-w", ws_name],
+    )
+
+    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+        data = json_util.load(f)
+        exp_names = [exp["name"] for exp in data["experiments"]]
+        # In loose mode, parent and child 2 are SUCCESS
+        assert "basic.working_wl.test_exp" in exp_names
+        assert "basic.working_wl.test_exp.2" in exp_names
+        assert "basic.working_wl.test_exp.1" not in exp_names
+
+    # Filter for FAILED: only child 1 is FAILED, parent is SUCCESS
+    workspace(
+        "analyze",
+        "-f",
+        "json",
+        "text",
+        "--where",
+        "'{experiment_status}' == 'FAILED'",
+        global_args=["-w", ws_name],
+    )
+
+    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+        data = json_util.load(f)
+        exp_names = [exp["name"] for exp in data["experiments"]]
+        assert "basic.working_wl.test_exp" not in exp_names
+        assert "basic.working_wl.test_exp.1" in exp_names
+        assert "basic.working_wl.test_exp.2" not in exp_names

--- a/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
@@ -10,6 +10,7 @@ import os
 
 import pytest
 
+import ramble.config
 from ramble.main import RambleCommand
 from ramble.util import json_util
 from ramble.util.foms import SummaryFoms
@@ -22,228 +23,209 @@ ramble_on = RambleCommand("on")
 
 
 def test_repeat_success_strict(mock_applications, make_workspace_from_config):
-    test_config = """
-ramble:
-  config:
-    repeat_success_strict: False
-  variables:
-    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
-    batch_submit: '{execute_experiment}'
-    processes_per_node: '16'
-    n_threads: '1'
-  applications:
-    basic:
-      workloads:
-        working_wl:
-          experiments:
-            test_exp:
-              n_repeats: 2
-              variables:
-                n_nodes: 1
-  software:
-    packages: {}
-    environments: {}
-"""
-    ws, ws_name = make_workspace_from_config(test_config)
+    ws, ws_name = make_workspace_from_config()
 
-    workspace("setup", global_args=["-w", ws_name])
-    ramble_on(global_args=["-w", ws_name])
-    workspace("analyze", global_args=["-w", ws_name])
-
-    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-        data = f.read()
-        assert "FAILED" not in data
-        assert f"summary::{SummaryFoms.N_TOTAL.value} = 2 repeats" in data
-        assert f"summary::{SummaryFoms.N_SUCCESS.value} = 2 repeats" in data
-
-    # Write mock output to fail one of the experiments
-    result_path = os.path.join(
-        ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
+    workspace(
+        "manage",
+        "experiments",
+        "basic",
+        "--workload-filter",
+        "working_wl",
+        "--experiment-name",
+        "test_exp",
+        "-v",
+        "n_nodes=1",
+        global_args=["-w", ws_name],
     )
-    with open(result_path, "w+", encoding="utf-8") as f:
-        f.write("")
 
-    workspace("analyze", global_args=["-w", ws_name])
+    with ramble.config.override("config:n_repeats", 2), ramble.config.override(
+        "config:repeat_success_strict", False
+    ):
+        workspace("setup", global_args=["-w", ws_name])
+        ramble_on(global_args=["-w", ws_name])
+        workspace("analyze", global_args=["-w", ws_name])
 
-    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-        data = f.read()
-        assert "SUCCESS" in data
-        assert "FAILED" in data
-        assert f"summary::{SummaryFoms.N_TOTAL.value} = 2 repeats" in data
-        assert f"summary::{SummaryFoms.N_SUCCESS.value} = 1 repeats" in data
+        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+            data = f.read()
+            assert "FAILED" not in data
+            assert f"summary::{SummaryFoms.N_TOTAL.value} = 2 repeats" in data
+            assert f"summary::{SummaryFoms.N_SUCCESS.value} = 2 repeats" in data
 
-    # Write mock output to fail the second experiment
-    result_path = os.path.join(
-        ws.experiment_dir, "basic", "working_wl", "test_exp.2", "test_exp.2.out"
-    )
-    with open(result_path, "w+", encoding="utf-8") as f:
-        f.write("")
+        # Write mock output to fail one of the experiments
+        result_path = os.path.join(
+            ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
+        )
+        with open(result_path, "w+", encoding="utf-8") as f:
+            f.write("")
 
-    workspace("analyze", global_args=["-w", ws_name])
+        workspace("analyze", global_args=["-w", ws_name])
 
-    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-        data = f.read()
-        assert "SUCCESS" not in data
-        assert f"summary::{SummaryFoms.N_TOTAL.value}" not in data
-        assert f"summary::{SummaryFoms.N_SUCCESS.value}" not in data
+        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+            data = f.read()
+            assert "SUCCESS" in data
+            assert "FAILED" in data
+            assert f"summary::{SummaryFoms.N_TOTAL.value} = 2 repeats" in data
+            assert f"summary::{SummaryFoms.N_SUCCESS.value} = 1 repeats" in data
+
+        # Write mock output to fail the second experiment
+        result_path = os.path.join(
+            ws.experiment_dir, "basic", "working_wl", "test_exp.2", "test_exp.2.out"
+        )
+        with open(result_path, "w+", encoding="utf-8") as f:
+            f.write("")
+
+        workspace("analyze", global_args=["-w", ws_name])
+
+        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+            data = f.read()
+            assert "SUCCESS" not in data
+            assert f"summary::{SummaryFoms.N_TOTAL.value}" not in data
+            assert f"summary::{SummaryFoms.N_SUCCESS.value}" not in data
 
 
 def test_repeat_analyze_where_experiment_status(mock_applications, make_workspace_from_config):
-    # Test strict mode (default: repeat_success_strict is True)
-    test_config = """
-ramble:
-  variables:
-    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
-    batch_submit: '{execute_experiment}'
-    processes_per_node: '16'
-    n_threads: '1'
-  applications:
-    basic:
-      workloads:
-        working_wl:
-          experiments:
-            test_exp:
-              n_repeats: 2
-              variables:
-                n_nodes: 1
-  software:
-    packages: {}
-    environments: {}
-"""
-    ws, ws_name = make_workspace_from_config(test_config)
+    ws, ws_name = make_workspace_from_config()
 
-    workspace("setup", global_args=["-w", ws_name])
-    ramble_on(global_args=["-w", ws_name])
-
-    # Fail repeat child 1
-    result_path = os.path.join(
-        ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
-    )
-    with open(result_path, "w+", encoding="utf-8") as f:
-        f.write("")
-
-    # First analyze without filters so child statuses are recorded
-    workspace("analyze", "-f", "json", "text", global_args=["-w", ws_name])
-
-    # Now analyze filtering for FAILED
     workspace(
-        "analyze",
-        "-f",
-        "json",
-        "text",
-        "--where",
-        "'{experiment_status}' == 'FAILED'",
+        "manage",
+        "experiments",
+        "basic",
+        "--workload-filter",
+        "working_wl",
+        "--experiment-name",
+        "test_exp",
+        "-v",
+        "n_nodes=1",
         global_args=["-w", ws_name],
     )
 
-    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
-        data = json_util.load(f)
-        exp_names = [exp["name"] for exp in data["experiments"]]
-        # In strict mode, since child 1 failed, both parent and child 1 must be present as FAILED
-        assert "basic.working_wl.test_exp" in exp_names
-        assert "basic.working_wl.test_exp.1" in exp_names
-        assert "basic.working_wl.test_exp.2" not in exp_names
+    with ramble.config.override("config:n_repeats", 2):
+        workspace("setup", global_args=["-w", ws_name])
+        ramble_on(global_args=["-w", ws_name])
 
-    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-        txt_data = f.read()
-        assert "Experiment basic.working_wl.test_exp figures of merit:" in txt_data
-        assert "Experiment basic.working_wl.test_exp.1 figures of merit:" in txt_data
-        assert "Experiment basic.working_wl.test_exp.2 figures of merit:" not in txt_data
+        # Fail repeat child 1
+        result_path = os.path.join(
+            ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
+        )
+        with open(result_path, "w+", encoding="utf-8") as f:
+            f.write("")
 
-    # Now analyze filtering for SUCCESS
-    workspace(
-        "analyze",
-        "-f",
-        "json",
-        "text",
-        "--where",
-        "'{experiment_status}' == 'SUCCESS'",
-        global_args=["-w", ws_name],
-    )
+        # First analyze without filters so child statuses are recorded
+        workspace("analyze", "-f", "json", "text", global_args=["-w", ws_name])
 
-    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
-        data = json_util.load(f)
-        exp_names = [exp["name"] for exp in data["experiments"]]
-        # In strict mode, parent is FAILED, so only child 2 is SUCCESS
-        assert "basic.working_wl.test_exp" not in exp_names
-        assert "basic.working_wl.test_exp.1" not in exp_names
-        assert "basic.working_wl.test_exp.2" in exp_names
+        # Now analyze filtering for FAILED
+        workspace(
+            "analyze",
+            "-f",
+            "json",
+            "text",
+            "--where",
+            "'{experiment_status}' == 'FAILED'",
+            global_args=["-w", ws_name],
+        )
+
+        with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+            data = json_util.load(f)
+            exp_names = [exp["name"] for exp in data["experiments"]]
+            # In strict mode, since child 1 failed, both parent and child 1
+            # must be present as FAILED
+            assert "basic.working_wl.test_exp" in exp_names
+            assert "basic.working_wl.test_exp.1" in exp_names
+            assert "basic.working_wl.test_exp.2" not in exp_names
+
+        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+            txt_data = f.read()
+            assert "Experiment basic.working_wl.test_exp figures of merit:" in txt_data
+            assert "Experiment basic.working_wl.test_exp.1 figures of merit:" in txt_data
+            assert "Experiment basic.working_wl.test_exp.2 figures of merit:" not in txt_data
+
+        # Now analyze filtering for SUCCESS
+        workspace(
+            "analyze",
+            "-f",
+            "json",
+            "text",
+            "--where",
+            "'{experiment_status}' == 'SUCCESS'",
+            global_args=["-w", ws_name],
+        )
+
+        with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+            data = json_util.load(f)
+            exp_names = [exp["name"] for exp in data["experiments"]]
+            # In strict mode, parent is FAILED, so only child 2 is SUCCESS
+            assert "basic.working_wl.test_exp" not in exp_names
+            assert "basic.working_wl.test_exp.1" not in exp_names
+            assert "basic.working_wl.test_exp.2" in exp_names
 
 
 def test_repeat_analyze_where_experiment_status_loose(
     mock_applications, make_workspace_from_config
 ):
-    # Test loose mode (repeat_success_strict is False)
-    test_config = """
-ramble:
-  config:
-    repeat_success_strict: False
-  variables:
-    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
-    batch_submit: '{execute_experiment}'
-    processes_per_node: '16'
-    n_threads: '1'
-  applications:
-    basic:
-      workloads:
-        working_wl:
-          experiments:
-            test_exp:
-              n_repeats: 2
-              variables:
-                n_nodes: 1
-  software:
-    packages: {}
-    environments: {}
-"""
-    ws, ws_name = make_workspace_from_config(test_config)
+    ws, ws_name = make_workspace_from_config()
 
-    workspace("setup", global_args=["-w", ws_name])
-    ramble_on(global_args=["-w", ws_name])
-
-    # Fail repeat child 1
-    result_path = os.path.join(
-        ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
-    )
-    with open(result_path, "w+", encoding="utf-8") as f:
-        f.write("")
-
-    # First analyze without filters so child statuses are recorded
-    workspace("analyze", "-f", "json", "text", global_args=["-w", ws_name])
-
-    # In loose mode, child 2 succeeded, so parent is SUCCESS
     workspace(
-        "analyze",
-        "-f",
-        "json",
-        "text",
-        "--where",
-        "'{experiment_status}' == 'SUCCESS'",
+        "manage",
+        "experiments",
+        "basic",
+        "--workload-filter",
+        "working_wl",
+        "--experiment-name",
+        "test_exp",
+        "-v",
+        "n_nodes=1",
         global_args=["-w", ws_name],
     )
 
-    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
-        data = json_util.load(f)
-        exp_names = [exp["name"] for exp in data["experiments"]]
-        # In loose mode, parent and child 2 are SUCCESS
-        assert "basic.working_wl.test_exp" in exp_names
-        assert "basic.working_wl.test_exp.2" in exp_names
-        assert "basic.working_wl.test_exp.1" not in exp_names
+    with ramble.config.override("config:n_repeats", 2), ramble.config.override(
+        "config:repeat_success_strict", False
+    ):
+        workspace("setup", global_args=["-w", ws_name])
+        ramble_on(global_args=["-w", ws_name])
 
-    # Filter for FAILED: only child 1 is FAILED, parent is SUCCESS
-    workspace(
-        "analyze",
-        "-f",
-        "json",
-        "text",
-        "--where",
-        "'{experiment_status}' == 'FAILED'",
-        global_args=["-w", ws_name],
-    )
+        # Fail repeat child 1
+        result_path = os.path.join(
+            ws.experiment_dir, "basic", "working_wl", "test_exp.1", "test_exp.1.out"
+        )
+        with open(result_path, "w+", encoding="utf-8") as f:
+            f.write("")
 
-    with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
-        data = json_util.load(f)
-        exp_names = [exp["name"] for exp in data["experiments"]]
-        assert "basic.working_wl.test_exp" not in exp_names
-        assert "basic.working_wl.test_exp.1" in exp_names
-        assert "basic.working_wl.test_exp.2" not in exp_names
+        # First analyze without filters so child statuses are recorded
+        workspace("analyze", "-f", "json", "text", global_args=["-w", ws_name])
+
+        # In loose mode, child 2 succeeded, so parent is SUCCESS
+        workspace(
+            "analyze",
+            "-f",
+            "json",
+            "text",
+            "--where",
+            "'{experiment_status}' == 'SUCCESS'",
+            global_args=["-w", ws_name],
+        )
+
+        with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+            data = json_util.load(f)
+            exp_names = [exp["name"] for exp in data["experiments"]]
+            # In loose mode, parent and child 2 are SUCCESS
+            assert "basic.working_wl.test_exp" in exp_names
+            assert "basic.working_wl.test_exp.2" in exp_names
+            assert "basic.working_wl.test_exp.1" not in exp_names
+
+        # Filter for FAILED: only child 1 is FAILED, parent is SUCCESS
+        workspace(
+            "analyze",
+            "-f",
+            "json",
+            "text",
+            "--where",
+            "'{experiment_status}' == 'FAILED'",
+            global_args=["-w", ws_name],
+        )
+
+        with open(os.path.join(ws.results_dir, "results.latest.json"), encoding="utf-8") as f:
+            data = json_util.load(f)
+            exp_names = [exp["name"] for exp in data["experiments"]]
+            assert "basic.working_wl.test_exp" not in exp_names
+            assert "basic.working_wl.test_exp.1" in exp_names
+            assert "basic.working_wl.test_exp.2" not in exp_names

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -4276,11 +4276,14 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 and base_exp_name not in self.experiment_set.experiments
             ):
                 insert_idx = base_exp_name.find(".chain")
-                repeat_exp_namespace = (
-                    base_exp_name[:insert_idx]
-                    + f".{n}"
-                    + base_exp_name[insert_idx:]
-                )
+                if insert_idx != -1:
+                    repeat_exp_namespace = (
+                        base_exp_name[:insert_idx]
+                        + f".{n}"
+                        + base_exp_name[insert_idx:]
+                    )
+                else:
+                    repeat_exp_namespace = f"{base_exp_name}.{n}"
             else:
                 base_exp_namespace = self.expander.experiment_namespace
                 repeat_exp_namespace = f"{base_exp_namespace}.{n}"

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3820,34 +3820,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         # If repeat_success_strict is true, one failed experiment will fail the whole set
         # If repeat_success_strict is false, any passing experiment will pass the whole set
-        repeat_success = False
-        exp_status_list = []
-        for exp in repeat_experiments:
-            if exp in self.experiment_set.experiments:
-                exp_inst = self.experiment_set.experiments[exp]
-            elif exp in self.experiment_set.chained_experiments:
-                exp_inst = self.experiment_set.chained_experiments[exp]
-            else:
-                continue
-
-            exp_status_list.append(exp_inst.get_status())
-
-        if workspace.repeat_success_strict:
-            if ExperimentStatus.FAILED in exp_status_list:
-                repeat_success = False
-            else:
-                repeat_success = True
-        else:
-            if ExperimentStatus.SUCCESS in exp_status_list:
-                repeat_success = True
-            else:
-                repeat_success = False
-
-        if repeat_success:
-            self.set_status(status=ExperimentStatus.SUCCESS)
-        else:
-            self.set_status(status=ExperimentStatus.FAILED)
-
+        status, exp_status_list = self.calculate_repeat_status(
+            workspace, return_status_list=True
+        )
+        self.set_status(status=status)
         self.result.finalize(workspace)
 
         logger.debug(
@@ -3868,6 +3844,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             # When strict success is off for repeats (loose success), skip failed exps
             if exp_inst.result.status == ExperimentStatus.FAILED:
                 continue
+
+            if not exp_inst.result.contexts:
+                exp_inst.result.read_cache(workspace, exp_inst)
 
             if exp_inst.result.contexts:
                 for context in exp_inst.result.contexts:
@@ -4282,13 +4261,125 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         """Add value to an in-memory FOM"""
         self._fom_map[fom_map_key] = value
 
+    def get_repeat_child_namespaces(self):
+        """Return a list of namespaces for all repeat children of this experiment"""
+        if not self.repeats.is_repeat_base or not self.experiment_set:
+            return []
+
+        base_exp_name = self.expander.experiment_name
+        base_exp_namespace = self.expander.experiment_namespace
+
+        repeat_namespaces = []
+        for n in range(1, self.repeats.n_repeats + 1):
+            if (
+                base_exp_name in self.experiment_set.chained_experiments
+                and base_exp_name not in self.experiment_set.experiments
+            ):
+                insert_idx = base_exp_name.find(".chain")
+                repeat_exp_namespace = (
+                    base_exp_name[:insert_idx]
+                    + f".{n}"
+                    + base_exp_name[insert_idx:]
+                )
+            else:
+                base_exp_namespace = self.expander.experiment_namespace
+                repeat_exp_namespace = f"{base_exp_namespace}.{n}"
+            repeat_namespaces.append(repeat_exp_namespace)
+        return repeat_namespaces
+
+    def get_repeat_children(self):
+        """Return a list of ApplicationBase instances for all repeat children"""
+        children = []
+        if not self.experiment_set:
+            return children
+        for exp in self.get_repeat_child_namespaces():
+            if exp in self.experiment_set.experiments:
+                children.append(self.experiment_set.experiments[exp])
+            elif exp in self.experiment_set.chained_experiments:
+                children.append(self.experiment_set.chained_experiments[exp])
+        return children
+
+    def calculate_repeat_status(
+        self, workspace=None, return_status_list=False
+    ):
+        """Calculate the status of a repeat base experiment from its children"""
+        if not self.repeats.is_repeat_base:
+            status = self.get_status()
+            return (status, [status]) if return_status_list else status
+
+        children = self.get_repeat_children()
+        if not children:
+            return (
+                (ExperimentStatus.UNKNOWN, [])
+                if return_status_list
+                else ExperimentStatus.UNKNOWN
+            )
+
+        exp_status_list = [c.get_status() for c in children]
+
+        if not exp_status_list or all(
+            s == ExperimentStatus.UNKNOWN for s in exp_status_list
+        ):
+            status = ExperimentStatus.UNKNOWN
+            return (status, exp_status_list) if return_status_list else status
+
+        strict = True
+        if workspace and hasattr(workspace, "repeat_success_strict"):
+            strict = workspace.repeat_success_strict
+        elif self.workspace and hasattr(
+            self.workspace, "repeat_success_strict"
+        ):
+            strict = self.workspace.repeat_success_strict
+        else:
+            strict = ramble.config.get(
+                "config:repeat_success_strict", default=True
+            )
+
+        if strict:
+            if any(
+                s
+                in (
+                    ExperimentStatus.FAILED,
+                    ExperimentStatus.CANCELLED,
+                    ExperimentStatus.TIMEOUT,
+                )
+                for s in exp_status_list
+            ):
+                status = ExperimentStatus.FAILED
+            elif all(s == ExperimentStatus.SUCCESS for s in exp_status_list):
+                status = ExperimentStatus.SUCCESS
+            else:
+                status = ExperimentStatus.UNKNOWN
+        else:
+            if any(s == ExperimentStatus.SUCCESS for s in exp_status_list):
+                status = ExperimentStatus.SUCCESS
+            elif all(
+                s
+                in (
+                    ExperimentStatus.FAILED,
+                    ExperimentStatus.CANCELLED,
+                    ExperimentStatus.TIMEOUT,
+                )
+                for s in exp_status_list
+            ):
+                status = ExperimentStatus.FAILED
+            else:
+                status = ExperimentStatus.UNKNOWN
+
+        return (status, exp_status_list) if return_status_list else status
+
     def read_status(self):
         """Read status from an experiment's status file, if possible.
 
         Set this experiment's status based on the status file in the experiment
         run directory, if it exists. If it doesn't exist, set its status to
-        ExperimentStatus.UNKNOWN
+        ExperimentStatus.UNKNOWN (or calculate from children if repeat base).
         """
+        if self.repeats.is_repeat_base:
+            status = self.calculate_repeat_status()
+            self.set_status(status)
+            return
+
         status_path = os.path.join(
             self.expander.expand_var_name(self.keywords.experiment_run_dir),
             self._status_file_name,
@@ -4314,6 +4405,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def get_status(self):
         """Get the status of this experiment"""
+        if self.repeats.is_repeat_base:
+            status = self.calculate_repeat_status()
+            self.set_status(status)
+            return status
+
         if self.keywords.experiment_status not in self.variables:
             self.read_status()
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -4267,39 +4267,33 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             return []
 
         base_exp_name = self.expander.experiment_name
-        base_exp_namespace = self.expander.experiment_namespace
+        is_chained = (
+            base_exp_name in self.experiment_set.chained_experiments
+            and base_exp_name not in self.experiment_set.experiments
+        )
 
-        repeat_namespaces = []
-        for n in range(1, self.repeats.n_repeats + 1):
-            if (
-                base_exp_name in self.experiment_set.chained_experiments
-                and base_exp_name not in self.experiment_set.experiments
-            ):
-                insert_idx = base_exp_name.find(".chain")
-                if insert_idx != -1:
-                    repeat_exp_namespace = (
-                        base_exp_name[:insert_idx]
-                        + f".{n}"
-                        + base_exp_name[insert_idx:]
-                    )
-                else:
-                    repeat_exp_namespace = f"{base_exp_name}.{n}"
-            else:
-                base_exp_namespace = self.expander.experiment_namespace
-                repeat_exp_namespace = f"{base_exp_namespace}.{n}"
-            repeat_namespaces.append(repeat_exp_namespace)
-        return repeat_namespaces
+        if is_chained and ".chain" in base_exp_name:
+            idx = base_exp_name.index(".chain")
+            prefix, suffix = base_exp_name[:idx], base_exp_name[idx:]
+            return [
+                f"{prefix}.{n}{suffix}"
+                for n in range(1, self.repeats.n_repeats + 1)
+            ]
+
+        base = (
+            base_exp_name if is_chained else self.expander.experiment_namespace
+        )
+        return [f"{base}.{n}" for n in range(1, self.repeats.n_repeats + 1)]
 
     def get_repeat_children(self):
         """Return a list of ApplicationBase instances for all repeat children"""
-        children = []
         if not self.experiment_set:
-            return children
+            return []
+        children = []
         for exp in self.get_repeat_child_namespaces():
-            if exp in self.experiment_set.experiments:
-                children.append(self.experiment_set.experiments[exp])
-            elif exp in self.experiment_set.chained_experiments:
-                children.append(self.experiment_set.chained_experiments[exp])
+            child = self.experiment_set.get_experiment(exp)
+            if child is not None:
+                children.append(child)
         return children
 
     def calculate_repeat_status(
@@ -4326,45 +4320,38 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             status = ExperimentStatus.UNKNOWN
             return (status, exp_status_list) if return_status_list else status
 
-        strict = True
-        if workspace and hasattr(workspace, "repeat_success_strict"):
-            strict = workspace.repeat_success_strict
-        elif self.workspace and hasattr(
-            self.workspace, "repeat_success_strict"
-        ):
-            strict = self.workspace.repeat_success_strict
-        else:
+        ws = workspace or self.workspace
+        strict = getattr(ws, "repeat_success_strict", None)
+        if strict is None:
             strict = ramble.config.get(
                 "config:repeat_success_strict", default=True
             )
 
+        failed_statuses = {
+            ExperimentStatus.FAILED,
+            ExperimentStatus.CANCELLED,
+            ExperimentStatus.TIMEOUT,
+        }
+        has_failed = any(s in failed_statuses for s in exp_status_list)
+        all_failed = all(s in failed_statuses for s in exp_status_list)
+        has_success = any(
+            s == ExperimentStatus.SUCCESS for s in exp_status_list
+        )
+        all_success = all(
+            s == ExperimentStatus.SUCCESS for s in exp_status_list
+        )
+
         if strict:
-            if any(
-                s
-                in (
-                    ExperimentStatus.FAILED,
-                    ExperimentStatus.CANCELLED,
-                    ExperimentStatus.TIMEOUT,
-                )
-                for s in exp_status_list
-            ):
+            if has_failed:
                 status = ExperimentStatus.FAILED
-            elif all(s == ExperimentStatus.SUCCESS for s in exp_status_list):
+            elif all_success:
                 status = ExperimentStatus.SUCCESS
             else:
                 status = ExperimentStatus.UNKNOWN
         else:
-            if any(s == ExperimentStatus.SUCCESS for s in exp_status_list):
+            if has_success:
                 status = ExperimentStatus.SUCCESS
-            elif all(
-                s
-                in (
-                    ExperimentStatus.FAILED,
-                    ExperimentStatus.CANCELLED,
-                    ExperimentStatus.TIMEOUT,
-                )
-                for s in exp_status_list
-            ):
+            elif all_failed:
                 status = ExperimentStatus.FAILED
             else:
                 status = ExperimentStatus.UNKNOWN
@@ -4379,8 +4366,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         ExperimentStatus.UNKNOWN (or calculate from children if repeat base).
         """
         if self.repeats.is_repeat_base:
-            status = self.calculate_repeat_status()
-            self.set_status(status)
+            self.set_status(self.calculate_repeat_status())
             return
 
         status_path = os.path.join(
@@ -4408,12 +4394,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def get_status(self):
         """Get the status of this experiment"""
-        if self.repeats.is_repeat_base:
-            status = self.calculate_repeat_status()
-            self.set_status(status)
-            return status
-
-        if self.keywords.experiment_status not in self.variables:
+        if (
+            self.repeats.is_repeat_base
+            or self.keywords.experiment_status not in self.variables
+        ):
             self.read_status()
 
         return self.variables[self.keywords.experiment_status]


### PR DESCRIPTION
hoist parent status calculation to allow parents to be queried by  `--where "'{experiment_status}' == FAILED`