### PR TITLE
DRY repo schema

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -49,16 +49,7 @@ import llnl.util.lang
 from llnl.util.filesystem import mkdirp, rename
 
 import ramble.paths
-import ramble.schema
 import ramble.schema.applications
-import ramble.schema.base_application_repos
-import ramble.schema.base_class_repos
-import ramble.schema.base_modifier_repos
-import ramble.schema.base_package_manager_repos
-import ramble.schema.base_platform_repos
-import ramble.schema.base_system_repos
-import ramble.schema.base_utility_repos
-import ramble.schema.base_workflow_manager_repos
 import ramble.schema.config
 import ramble.schema.env_vars
 import ramble.schema.filter_groups
@@ -66,22 +57,16 @@ import ramble.schema.formatted_executables
 import ramble.schema.internals
 import ramble.schema.licenses
 import ramble.schema.mirrors
-import ramble.schema.modifier_repos
 import ramble.schema.modifiers
-import ramble.schema.package_manager_repos
-import ramble.schema.platform_repos
-
-# Objects
-import ramble.schema.repos
+import ramble.schema.repo_schema
 import ramble.schema.software
 import ramble.schema.success_criteria
-import ramble.schema.system_repos
 import ramble.schema.tables
-import ramble.schema.utility_repos
+import ramble.schema.utilities
 import ramble.schema.variables
 import ramble.schema.variants
-import ramble.schema.workflow_manager_repos
 import ramble.schema.workspace
+import ramble.schema.zips
 from ramble.error import RambleError
 from ramble.util import cpus
 from ramble.util.logger import logger
@@ -110,21 +95,7 @@ section_schemas: Dict[str, Dict[str, Any]] = {
     "variants": ramble.schema.variants.schema,
     "zips": ramble.schema.zips.schema,
     "utilities": ramble.schema.utilities.schema,
-    "repos": ramble.schema.repos.schema,
-    "modifier_repos": ramble.schema.modifier_repos.schema,
-    "package_manager_repos": ramble.schema.package_manager_repos.schema,
-    "system_repos": ramble.schema.system_repos.schema,
-    "platform_repos": ramble.schema.platform_repos.schema,
-    "workflow_manager_repos": ramble.schema.workflow_manager_repos.schema,
-    "base_application_repos": ramble.schema.base_application_repos.schema,
-    "base_class_repos": ramble.schema.base_class_repos.schema,
-    "base_modifier_repos": ramble.schema.base_modifier_repos.schema,
-    "base_package_manager_repos": ramble.schema.base_package_manager_repos.schema,
-    "base_workflow_manager_repos": ramble.schema.base_workflow_manager_repos.schema,
-    "base_system_repos": ramble.schema.base_system_repos.schema,
-    "base_platform_repos": ramble.schema.base_platform_repos.schema,
-    "utility_repos": ramble.schema.utility_repos.schema,
-    "base_utility_repos": ramble.schema.base_utility_repos.schema,
+    **ramble.schema.repo_schema.schemas,
 }
 
 # Same as above, but including keys for workspaces

--- a/lib/ramble/ramble/schema/__init__.py
+++ b/lib/ramble/ramble/schema/__init__.py
@@ -57,3 +57,13 @@ def _make_validator():
 
 
 Validator = llnl.util.lang.Singleton(_make_validator)
+
+
+def __getattr__(name: str):
+    import importlib
+
+    try:
+        mod = importlib.import_module(f"ramble.schema.{name}")
+        return mod
+    except ModuleNotFoundError as err:
+        raise AttributeError(f"module 'ramble.schema' has no attribute '{name}'") from err

--- a/lib/ramble/ramble/schema/__init__.py
+++ b/lib/ramble/ramble/schema/__init__.py
@@ -63,7 +63,8 @@ def __getattr__(name: str):
     import importlib
 
     try:
-        mod = importlib.import_module(f"ramble.schema.{name}")
-        return mod
+        return importlib.import_module(f"ramble.schema.{name}")
     except ModuleNotFoundError as err:
-        raise AttributeError(f"module 'ramble.schema' has no attribute '{name}'") from err
+        if err.name == f"ramble.schema.{name}":
+            raise AttributeError(f"module 'ramble.schema' has no attribute '{name}'") from err
+        raise

--- a/lib/ramble/ramble/schema/base_application_repos.py
+++ b/lib/ramble/ramble/schema/base_application_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_application_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_application_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble base application repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/base_class_repos.py
+++ b/lib/ramble/ramble/schema/base_class_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_class_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_class_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble base class repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/base_modifier_repos.py
+++ b/lib/ramble/ramble/schema/base_modifier_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_modifier_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_modifier_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble base modifier repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/base_package_manager_repos.py
+++ b/lib/ramble/ramble/schema/base_package_manager_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_package_manager_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_package_manager_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble base package manager repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/base_platform_repos.py
+++ b/lib/ramble/ramble/schema/base_platform_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_platform_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_platform_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble base platform repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/base_system_repos.py
+++ b/lib/ramble/ramble/schema/base_system_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_system_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_system_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble base system repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/base_utility_repos.py
+++ b/lib/ramble/ramble/schema/base_utility_repos.py
@@ -6,27 +6,18 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-"""Schema for repos.yaml configuration file.
+"""Schema for base_utility_repos.yaml configuration file.
 
-.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/repos.py
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/base_utility_repos.py
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_utility_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_utility_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/base_workflow_manager_repos.py
+++ b/lib/ramble/ramble/schema/base_workflow_manager_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "base_workflow_manager_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "base_workflow_manager_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble base workflow manager repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -15,13 +15,6 @@
 from llnl.util.lang import union_dicts
 
 import ramble.schema.applications
-import ramble.schema.base_application_repos
-import ramble.schema.base_class_repos
-import ramble.schema.base_modifier_repos
-import ramble.schema.base_package_manager_repos
-import ramble.schema.base_platform_repos
-import ramble.schema.base_system_repos
-import ramble.schema.base_workflow_manager_repos
 import ramble.schema.config
 import ramble.schema.env_vars
 import ramble.schema.filter_groups
@@ -29,52 +22,35 @@ import ramble.schema.formatted_executables
 import ramble.schema.internals
 import ramble.schema.licenses
 import ramble.schema.mirrors
-import ramble.schema.modifier_repos
 import ramble.schema.modifiers
-import ramble.schema.package_manager_repos
-import ramble.schema.platform_repos
-import ramble.schema.repos
+import ramble.schema.repo_schema
 import ramble.schema.software
 import ramble.schema.success_criteria
-import ramble.schema.system_repos
 import ramble.schema.tables
 import ramble.schema.utilities
 import ramble.schema.variables
 import ramble.schema.variants
-import ramble.schema.workflow_manager_repos
 import ramble.schema.zips
 
 #: Properties for inclusion in other schemas
 properties = union_dicts(
     ramble.schema.applications.properties,
-    ramble.schema.base_application_repos.properties,
-    ramble.schema.base_class_repos.properties,
-    ramble.schema.base_modifier_repos.properties,
-    ramble.schema.base_package_manager_repos.properties,
-    ramble.schema.base_workflow_manager_repos.properties,
-    ramble.schema.base_system_repos.properties,
-    ramble.schema.base_platform_repos.properties,
     ramble.schema.config.properties,
+    ramble.schema.env_vars.properties,
+    ramble.schema.filter_groups.properties,
     ramble.schema.formatted_executables.properties,
+    ramble.schema.internals.properties,
     ramble.schema.licenses.properties,
     ramble.schema.mirrors.properties,
-    ramble.schema.modifier_repos.properties,
-    ramble.schema.package_manager_repos.properties,
-    ramble.schema.system_repos.properties,
-    ramble.schema.platform_repos.properties,
-    ramble.schema.repos.properties,
+    ramble.schema.modifiers.properties,
+    ramble.schema.repo_schema.properties,
     ramble.schema.software.properties,
     ramble.schema.success_criteria.properties,
     ramble.schema.tables.properties,
+    ramble.schema.utilities.properties,
     ramble.schema.variables.properties,
     ramble.schema.variants.properties,
-    ramble.schema.env_vars.properties,
-    ramble.schema.filter_groups.properties,
-    ramble.schema.internals.properties,
-    ramble.schema.modifiers.properties,
-    ramble.schema.workflow_manager_repos.properties,
     ramble.schema.zips.properties,
-    ramble.schema.utilities.properties,
 )
 
 #: Full schema with metadata

--- a/lib/ramble/ramble/schema/modifier_repos.py
+++ b/lib/ramble/ramble/schema/modifier_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "modifier_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "modifier_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble modifier repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/package_manager_repos.py
+++ b/lib/ramble/ramble/schema/package_manager_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "package_manager_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "package_manager_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble package manager repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/platform_repos.py
+++ b/lib/ramble/ramble/schema/platform_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "platform_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "platform_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble platform repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/repo_schema.py
+++ b/lib/ramble/ramble/schema/repo_schema.py
@@ -1,0 +1,74 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Helper utilities and schemas for repository configurations in Ramble.
+
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/repo_schema.py
+   :lines: 13-
+"""
+
+from typing import Any, Dict, List, Optional
+
+
+def make_repo_properties(section_name: str) -> Dict[str, Any]:
+    """Generates the jsonschema properties dict for a repository configuration section."""
+    return {
+        section_name: {
+            "type": "array",
+            "default": [],
+            "items": {"type": "string"},
+        },
+    }
+
+
+def make_repo_schema(section_name: str, title: Optional[str] = None) -> Dict[str, Any]:
+    """Generates the full jsonschema dict for a repository configuration section."""
+    if title is None:
+        clean_name = section_name.replace("_repos", "").replace("_", " ")
+        if clean_name == "repos":
+            clean_name = ""
+        else:
+            clean_name = f" {clean_name}"
+        title = f"Ramble{clean_name} repository configuration file schema"
+    return {
+        "$schema": "http://json-schema.org/schema#",
+        "title": title,
+        "type": "object",
+        "additionalProperties": False,
+        "properties": make_repo_properties(section_name),
+    }
+
+
+#: All repository configuration sections in Ramble
+REPO_SECTIONS: List[str] = [
+    "repos",
+    "modifier_repos",
+    "package_manager_repos",
+    "workflow_manager_repos",
+    "system_repos",
+    "platform_repos",
+    "base_class_repos",
+    "base_application_repos",
+    "base_modifier_repos",
+    "base_package_manager_repos",
+    "base_workflow_manager_repos",
+    "base_system_repos",
+    "base_platform_repos",
+    "utility_repos",
+    "base_utility_repos",
+]
+
+#: Dict containing properties for all repository sections
+properties: Dict[str, Any] = {}
+for section in REPO_SECTIONS:
+    properties.update(make_repo_properties(section))
+
+#: Dict mapping section name -> full schema for that repository section
+schemas: Dict[str, Dict[str, Any]] = {
+    section: make_repo_schema(section) for section in REPO_SECTIONS
+}

--- a/lib/ramble/ramble/schema/repos.py
+++ b/lib/ramble/ramble/schema/repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/system_repos.py
+++ b/lib/ramble/ramble/schema/system_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "system_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "system_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble system repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/utility_repos.py
+++ b/lib/ramble/ramble/schema/utility_repos.py
@@ -6,27 +6,18 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-"""Schema for repos.yaml configuration file.
+"""Schema for utility_repos.yaml configuration file.
 
-.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/repos.py
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/utility_repos.py
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "utility_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "utility_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/schema/workflow_manager_repos.py
+++ b/lib/ramble/ramble/schema/workflow_manager_repos.py
@@ -12,21 +12,12 @@
    :lines: 13-
 """
 
-#: Properties for inclusion in other schemas
-properties = {
-    "workflow_manager_repos": {
-        "type": "array",
-        "default": [],
-        "items": {"type": "string"},
-    },
-}
+from ramble.schema.repo_schema import make_repo_properties, make_repo_schema
 
+section_name = "workflow_manager_repos"
+
+#: Properties for inclusion in other schemas
+properties = make_repo_properties(section_name)
 
 #: Full schema with metadata
-schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "title": "Ramble workflow manager repository configuration file schema",
-    "type": "object",
-    "additionalProperties": False,
-    "properties": properties,
-}
+schema = make_repo_schema(section_name)

--- a/lib/ramble/ramble/test/repo_schema.py
+++ b/lib/ramble/ramble/test/repo_schema.py
@@ -1,0 +1,50 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.config
+import ramble.repository
+import ramble.schema.merged
+import ramble.schema.repo_schema
+
+
+def test_repo_schema_generator():
+    props = ramble.schema.repo_schema.make_repo_properties("my_custom_repos")
+    assert "my_custom_repos" in props
+    assert props["my_custom_repos"]["type"] == "array"
+
+    schema = ramble.schema.repo_schema.make_repo_schema("my_custom_repos")
+    assert schema["type"] == "object"
+    assert schema["properties"] == props
+    assert schema["title"] == "Ramble my custom repository configuration file schema"
+
+
+def test_repo_sections_match_object_types():
+    repo_sections_from_types = {
+        obj_info["config_section"] for obj_info in ramble.repository.type_definitions.values()
+    }
+    repo_sections_from_schema = set(ramble.schema.repo_schema.REPO_SECTIONS)
+    assert repo_sections_from_types == repo_sections_from_schema
+
+
+def test_merged_properties_contain_all_repo_sections():
+    for section in ramble.schema.repo_schema.REPO_SECTIONS:
+        assert section in ramble.schema.merged.properties
+        assert section in ramble.config.section_schemas
+
+
+@pytest.mark.parametrize("section_name", ramble.schema.repo_schema.REPO_SECTIONS)
+def test_individual_repo_schema_modules(section_name):
+    import importlib
+
+    mod = importlib.import_module(f"ramble.schema.{section_name}")
+    assert hasattr(mod, "properties")
+    assert hasattr(mod, "schema")
+    assert section_name in mod.properties
+    assert mod.schema["properties"] == mod.properties


### PR DESCRIPTION
In a different conversation gemini notes that `ramble.schema.base_utility_repos.properties` and `ramble.schema.utility_repos.properties` were (unintentionally?) missing from the repo import. That sent me down a side quest to see if I could DRY some of the repeated schema/properties code

Some things are repeated in almost every file, such as:

```
properties = {
    "<name>": {
        "type": "array",
        "default": [],
        "items": {"type": "string"},
    },
```