### PR TITLE
Do not exit early in repo listing

### DIFF
--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -343,7 +343,7 @@ def repo_list(args):
             logger.msg(msg)
 
         if not repos:
-            return
+            continue
 
         max_ns_len = max(len(r.namespace) for r in repos)
         for repo in repos:

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -973,25 +973,6 @@ class RepoPath:
                 return True
         return False
 
-    # TODO: DWJ - Maybe we don't need this? Are we going to have virtual
-    #             objects
-    # def is_virtual(self, obj_name, use_index=True):
-    #     """True if the object with this name is virtual,
-    #        False otherwise.
-    #
-    #     Set `use_index` False when calling from a code block that could
-    #     be run during the computation of the provider index."""
-    #     have_name = obj_name is not None
-    #     if have_name and not isinstance(obj_name, str):
-    #         raise ValueError(
-    #             "is_virtual(): expected object name, got %s" %
-    #             type(obj_name))
-    #     if use_index:
-    #         return have_name and app_name in self.provider_index
-    #     else:
-    #         return have_name and (not self.exists(app_name) or
-    #                               self.get_app_class(app_name).virtual)
-
     def __contains__(self, obj_name):
         return self.exists(obj_name)
 

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -197,3 +197,13 @@ def test_singular_type_repo_commands(mutable_config, tmpdir, type_arg):
     repo("remove", "-t", type_arg, "--scope=site", repo_path)
     output = repo("list", "-t", type_arg, "--scope=site", output=str)
     assert f"mockrepo_{type_arg}" not in output
+
+
+def test_repo_list_multitype_non_application_scope(mutable_empty_config, tmpdir):
+    """Test that repo list (type 'any') lists modifiers even if no applications are in scope."""
+    mod_repo_path = str(tmpdir.join("mod_repo"))
+    repo("create", mod_repo_path, "mockmodrepo", "-t", "modifiers")
+    repo("add", "-t", "modifiers", mod_repo_path)
+
+    output = repo("list", output=str)
+    assert "mockmodrepo" in output


### PR DESCRIPTION
Right now when it sees a particular object type has 0 repo, it returns. This is usually OK since we have built-in repos for each object type, but can be problematic when querying with specific scope (`--scope`).

Incidentally, remove an unused chunk of comment.