### PR TITLE
Fix up the normalize_path_or_url edge case

### DIFF
--- a/lib/ramble/ramble/test/util/path.py
+++ b/lib/ramble/ramble/test/util/path.py
@@ -24,6 +24,9 @@ import ramble.util.path
         ("gs://my-bucket", "gs://my-bucket"),
         ("gs://my-bucket/", "gs://my-bucket"),
         ("gs://my-bucket///", "gs://my-bucket"),
+        ("/", "/"),
+        ("///", "/"),
+        ("", ""),
     ],
 )
 def test_normalize_path_or_url(path, expect):

--- a/lib/ramble/ramble/util/path.py
+++ b/lib/ramble/ramble/util/path.py
@@ -75,7 +75,7 @@ def canonicalize_path(path):
 
 def normalize_path_or_url(path):
     """Convert a scheme-less path to absolute local path
-    Also, remove trailing back-slashes from the input path
+    Also, remove trailing slashes from the input path
 
     Args:
         path (str): Input path
@@ -83,11 +83,10 @@ def normalize_path_or_url(path):
     Returns:
         str: Absolute local path or cleaned remote url
     """
+    if not path:
+        return path
 
-    # Remove trailing back-slashes from path
-    real_path = path.rstrip("/")
-
-    parsed = urllib.parse.urlparse(real_path)
+    parsed = urllib.parse.urlparse(path)
     if not parsed.scheme:
-        return os.path.abspath(real_path)
-    return real_path
+        return os.path.abspath(path)
+    return path.rstrip("/")


### PR DESCRIPTION
Previously when given a root path (`/`), it would erroneously return an empty string.