### PR TITLE
Ensure context manager cleanups work as expected

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -1551,15 +1551,19 @@ def command_variable(
 @contextlib.contextmanager
 def when(condition):
     ramble.language.language_base.DirectiveMeta.push_to_context(condition)
-    yield
-    ramble.language.language_base.DirectiveMeta.pop_from_context()
+    try:
+        yield
+    finally:
+        ramble.language.language_base.DirectiveMeta.pop_from_context()
 
 
 @contextlib.contextmanager
 def default_args(**kwargs):
     ramble.language.language_base.DirectiveMeta.push_default_args(kwargs)
-    yield
-    ramble.language.language_base.DirectiveMeta.pop_default_args()
+    try:
+        yield
+    finally:
+        ramble.language.language_base.DirectiveMeta.pop_default_args()
 
 
 @shared_directive("object_modifiers")

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -402,12 +402,13 @@ def use_repositories(*paths_and_repos, object_type=default_type):
     saved = paths[object_type]
     remove_from_meta = set_path(temporary_repositories, object_type=object_type)
 
-    yield temporary_repositories
-
-    # Restore _path and sys.meta_path
-    if remove_from_meta:
-        sys.meta_path.remove(temporary_repositories)
-    paths[object_type] = saved
+    try:
+        yield temporary_repositories
+    finally:
+        # Restore _path and sys.meta_path
+        if remove_from_meta and temporary_repositories in sys.meta_path:
+            sys.meta_path.remove(temporary_repositories)
+        paths[object_type] = saved
 
 
 def autospec(function):

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -670,3 +670,27 @@ def test_workload_directive_where(app_class):
     assert wl_name in app_inst.workloads[_FS]
     assert app_inst.workloads[_FS][wl_name].where == ["{n_nodes} <= 4"]
     assert app_inst.workloads[_FS][wl_name].exclude_where == ["{n_gpus} == 0"]
+
+
+def test_when_context_cleanup_on_exception():
+    from ramble.language.language_base import DirectiveMeta
+    from ramble.language.shared_language import when
+
+    initial_len = len(DirectiveMeta._when_constraints_from_context)
+    with pytest.raises(RuntimeError):
+        with when("+foo"):
+            assert len(DirectiveMeta._when_constraints_from_context) == initial_len + 1
+            raise RuntimeError("test error")
+    assert len(DirectiveMeta._when_constraints_from_context) == initial_len
+
+
+def test_default_args_context_cleanup_on_exception():
+    from ramble.language.language_base import DirectiveMeta
+    from ramble.language.shared_language import default_args
+
+    initial_len = len(DirectiveMeta._default_args)
+    with pytest.raises(RuntimeError):
+        with default_args(foo="bar"):
+            assert len(DirectiveMeta._default_args) == initial_len + 1
+            raise RuntimeError("test error")
+    assert len(DirectiveMeta._default_args) == initial_len

--- a/lib/ramble/ramble/test/repository.py
+++ b/lib/ramble/ramble/test/repository.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import sys
+
 import pytest
 
 import ramble.repository
@@ -206,3 +208,13 @@ def test_simplify_object_type_enum_passthrough():
 def test_simplify_object_type_invalid(invalid_type):
     with pytest.raises(ramble.repository.UnknownObjectTypeError):
         ramble.repository.simplify_object_type(invalid_type)
+
+
+def test_use_repositories_exception_cleanup(extra_repo):
+    orig_path = ramble.repository.paths[ramble.repository.ObjectTypes.applications]
+    orig_meta_path = list(sys.meta_path)
+    with pytest.raises(RuntimeError):
+        with ramble.repository.use_repositories(extra_repo[0].root):
+            raise RuntimeError("test error inside context")
+    assert ramble.repository.paths[ramble.repository.ObjectTypes.applications] is orig_path
+    assert sys.meta_path == orig_meta_path

--- a/lib/ramble/ramble/test/util/logger.py
+++ b/lib/ramble/ramble/test/util/logger.py
@@ -111,3 +111,18 @@ def test_add_log_context_unbalanced_nested(logger, tmpdir):
     # Clean up
     logger.remove_log()
     logger.remove_log()
+
+
+def test_configure_colors_exception_cleanup(logger):
+    import llnl.util.tty.color as color
+
+    old_color_setting = color._force_color
+    try:
+        color.set_color_when(True)
+        with pytest.raises(RuntimeError):
+            with logger.configure_colors(stream=object()):
+                assert color.get_color_when() is False
+                raise RuntimeError("test error")
+        assert color.get_color_when() is True
+    finally:
+        color.set_color_when(old_color_setting)

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -158,10 +158,12 @@ class Logger:
     @contextmanager
     def configure_colors(self, **kwargs):
         old_value = color.get_color_when()
-        if "stream" in kwargs:
-            color.set_color_when("never")
-        yield
-        color.set_color_when(old_value)
+        try:
+            if "stream" in kwargs:
+                color.set_color_when("never")
+            yield
+        finally:
+            color.set_color_when(old_value)
 
     def all_msg(self, *args, **kwargs):
         """Print a message to all logs


### PR DESCRIPTION
Without the try...finally block, the cleanup following the `yield` statement may not be executed if exceptions are raised in the `with` block.