### PR TITLE
cmd/edit: open application .tpl files alongside application.py if they exist

### DIFF
--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -199,8 +199,16 @@ def edit(parser, args):
             if not os.access(path, os.R_OK):
                 logger.die(f"Insufficient permissions on '{path}'!")
 
+            edit_files = [path]
+            # If editing an application, also include its template files (.tpl) if exists
+            if matches[0]["type"] == "applications":
+                obj_dir = os.path.dirname(path)
+                tpl_pattern = os.path.join(glob.escape(obj_dir), "*.tpl")
+                tpl_files = sorted(f for f in glob.glob(tpl_pattern) if os.path.isfile(f))
+                edit_files.extend(tpl_files)
+
             try:
-                editor(path)
+                editor(*edit_files)
             except TypeError:
                 logger.die("No valid editor was found.")
             return

--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -201,7 +201,7 @@ def edit(parser, args):
 
             edit_files = [path]
             # If editing an application, also include its template files (.tpl) if exists
-            if matches[0]["type"] == "applications":
+            if matches[0]["type"] == ramble.repository.ObjectTypes.applications.name:
                 obj_dir = os.path.dirname(path)
                 tpl_pattern = os.path.join(glob.escape(obj_dir), "*.tpl")
                 tpl_files = sorted(f for f in glob.glob(tpl_pattern) if os.path.isfile(f))

--- a/lib/ramble/ramble/test/cmd/edit.py
+++ b/lib/ramble/ramble/test/cmd/edit.py
@@ -324,3 +324,19 @@ def test_edit_repo_path(mock_applications, mock_editor):
     edit("--repo", repo_dir, "basic")
     assert len(mock_editor) == 1
     assert "repos/builtin.mock/applications/basic/application.py" in mock_editor[0]
+
+
+def test_edit_application_with_tpl_files(mock_applications, monkeypatch):
+    """Test that ramble edit opens .tpl files alongside application.py"""
+    recorded_calls = []
+
+    def mock_editor(*args, **kwargs):
+        recorded_calls.extend(args)
+
+    monkeypatch.setattr("ramble.cmd.edit.editor", mock_editor)
+    edit("template")
+
+    assert len(recorded_calls) == 3
+    assert recorded_calls[0].endswith("application.py")
+    assert recorded_calls[1].endswith("bar.tpl")
+    assert recorded_calls[2].endswith("script.sh.tpl")


### PR DESCRIPTION
### Description
When editing an application definition via `ramble edit <app_name>`, only `application.py` was previously opened. This change updates `ramble edit` to also discover and open any `.tpl` template files located in the application directory.

This brings the behavior inline with `ramble workspace edit`.

### Verification
- Added unit test `test_edit_application_with_tpl_files` in `lib/ramble/ramble/test/cmd/edit.py` to verify opening `.tpl` template files alongside `application.py`.
- Tested `ramble edit` manually with applications containing `.tpl` files (e.g. `fio`, `iozone`) and verified that both `application.py` and all accompanying `*.tpl` files are passed to `$EDITOR`.
- Verified that applications without `.tpl` files and non-application editing remain unaffected.