### PR TITLE
add type cast protection to wm type casting

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -359,4 +359,5 @@ ramble:
         f.write(job_id_content)
 
     # Analyze should complete without crashing due to empty or invalid files
-    workspace("analyze", global_args=["-D", ws.root])
+    out = workspace("analyze", "-p", global_args=["-D", ws.root])
+    assert "Status = FAILED" in out

--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -314,3 +314,49 @@ ramble:
             filename,
         )
         assert os.path.isfile(archived_path)
+
+
+@pytest.mark.parametrize(
+    "end_time_content,job_id_content",
+    [
+        ("", ""),
+        ("   \n", "12345"),
+        ("not_a_float", "12345"),
+        ("1700000000", ""),
+    ],
+)
+def test_slurm_analyze_empty_or_invalid_files(
+    make_workspace_from_config, end_time_content, job_id_content
+):
+    test_config = """
+ramble:
+  variants:
+    workflow_manager: slurm
+  variables:
+    processes_per_node: 1
+    n_nodes: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test: {}
+"""
+    ws, _ = make_workspace_from_config(test_config)
+
+    workspace("setup", "--dry-run", global_args=["-D", ws.root])
+
+    experiment_dir = os.path.join(
+        ws.experiment_dir, "hostname", "local", "test"
+    )
+
+    end_time_path = os.path.join(experiment_dir, ".slurm_script_end_time")
+    with open(end_time_path, "w", encoding="utf-8") as f:
+        f.write(end_time_content)
+
+    job_id_path = os.path.join(experiment_dir, ".slurm_job")
+    with open(job_id_path, "w", encoding="utf-8") as f:
+        f.write(job_id_content)
+
+    # Analyze should complete without crashing due to empty or invalid files
+    workspace("analyze", global_args=["-D", ws.root])

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -180,7 +180,6 @@ class Slurm(WorkflowManagerBase):
 
     @property
     def template_render_vars(self):
-        vars = {}
         app_inst = self.app_inst
         expander = app_inst.expander
         # Adding pre-defined and custom headers
@@ -204,15 +203,13 @@ class Slurm(WorkflowManagerBase):
         partition = expander.expand_var_name("slurm_partition")
         if partition:
             pragmas.append("#SBATCH -p {slurm_partition}")
-        extra_headers = (
-            expander.expand_var_name("extra_sbatch_headers")
-            .strip()
-            .split("\n")
-        )
-        pragmas = pragmas + extra_headers
+        extra_headers = expander.expand_var_name(
+            "extra_sbatch_headers"
+        ).strip()
+        if extra_headers:
+            pragmas.extend(extra_headers.splitlines())
         header_str = "\n".join(self.conditional_expand(pragmas))
         return {
-            **vars,
             "workflow_pragmas": header_str,
             "workflow_hostfile_cmd": self.runner.get_hostfile_cmd(),
         }
@@ -222,26 +219,28 @@ class Slurm(WorkflowManagerBase):
         run_dir = self.app_inst.expander.experiment_run_dir
         end_time_file = os.path.join(run_dir, ".slurm_script_end_time")
         job_id_file = os.path.join(run_dir, ".slurm_job")
-        if not os.path.isfile(end_time_file) or not os.path.isfile(
-            job_id_file
-        ):
+        if not (os.path.isfile(end_time_file) and os.path.isfile(job_id_file)):
             return
-        with open(end_time_file, encoding="utf-8") as f:
-            script_end_time = float(f.read().strip())
-        with open(job_id_file, encoding="utf-8") as f:
-            job_id = f.read().strip()
-        sacct_cmd = Executable("sacct")
         try:
+            with open(end_time_file, encoding="utf-8") as f:
+                script_end_time = float(f.read().strip())
+
+            with open(job_id_file, encoding="utf-8") as f:
+                job_id = f.read().strip()
+            if not job_id:
+                logger.warn(f"Job ID file {job_id_file} is empty")
+                return
+
+            sacct_cmd = Executable("sacct")
             job_end_time_str = sacct_cmd(
                 "-j", job_id, "-X", "-n", "--format=End", output=str
             ).strip()
             # sacct by default reports timestamp in local timezone
-            # TODO: can use more convenient method with python 3.7+
             job_end_time = datetime.datetime.strptime(
                 job_end_time_str, "%Y-%m-%dT%H:%M:%S"
             ).timestamp()
             duration = int(job_end_time - script_end_time)
-        except (ProcessError, ValueError) as e:
+        except (ProcessError, ValueError, OSError) as e:
             logger.warn(f"Failed to get job end time with error {e}")
         else:
             fom_key = "slurm-job-termination-overhead"
@@ -258,7 +257,7 @@ class Slurm(WorkflowManagerBase):
         query_cmd = Executable(query_script)
         try:
             query_cmd(output=os.devnull)
-        except ProcessError as e:
+        except (ProcessError, OSError) as e:
             # Only log a warning as this is not considered a critical step
             logger.warn(f"batch_query returns error {e}")
         self._get_job_termination_overhead()
@@ -267,17 +266,27 @@ class Slurm(WorkflowManagerBase):
         expander = self.app_inst.expander
         run_dir = expander.expand_var_name("experiment_run_dir")
         job_id_file = os.path.join(run_dir, ".slurm_job")
-        status = ExperimentStatus.UNRESOLVED
         if not os.path.isfile(job_id_file):
             logger.warn("job_id file is missing")
-            return status
-        with open(job_id_file, encoding="utf-8") as f:
-            job_id = f.read().strip()
+            return ExperimentStatus.UNRESOLVED
+        try:
+            with open(job_id_file, encoding="utf-8") as f:
+                job_id = f.read().strip()
+        except OSError as e:
+            logger.warn(f"Failed to read job_id file {job_id_file}: {e}")
+            return ExperimentStatus.UNRESOLVED
+        if not job_id:
+            logger.warn(f"job_id file {job_id_file} is empty")
+            return ExperimentStatus.UNRESOLVED
+
         self.runner.set_dry_run(workspace.dry_run)
         wm_status_raw = self.runner.get_status(job_id)
         wm_status = _STATUS_MAP.get(wm_status_raw)
-        if wm_status is not None and hasattr(ExperimentStatus, wm_status):
-            status = getattr(ExperimentStatus, wm_status)
+        status = (
+            getattr(ExperimentStatus, wm_status)
+            if wm_status and hasattr(ExperimentStatus, wm_status)
+            else ExperimentStatus.UNRESOLVED
+        )
         if status == ExperimentStatus.UNRESOLVED:
             logger.warn(
                 f"The slurm workflow manager failed to resolve the status of job {job_id}. "
@@ -368,7 +377,6 @@ class SlurmRunner:
         self.squeue_runner = None
         self.sacct_runner = None
         self.sinfo_runner = None
-        self.run_dir = None
 
     def _ensure_runner(self, runner_name: str):
         attr = f"{runner_name}_runner"
@@ -388,24 +396,23 @@ class SlurmRunner:
     def get_status(self, job_id):
         if self.dry_run:
             return None
-        self._ensure_runner("squeue")
-        squeue_args = ["-h", "-o", "%t", "-j", job_id]
+        status_out = ""
         try:
+            self._ensure_runner("squeue")
+            squeue_args = ["-h", "-o", "%t", "-j", job_id]
             status_out = self.squeue_runner.command(
                 *squeue_args, output=str, error=os.devnull
             )
-        except ProcessError as e:
-            status_out = ""
+        except (ProcessError, RunnerError, OSError) as e:
             logger.debug(
                 f"squeue returns error {e}. This is normal if the job has already been completed."
             )
         if not status_out:
-            self._ensure_runner("sacct")
-            sacct_args = ["-o", "state", "-X", "-n", "-j", job_id]
             try:
+                self._ensure_runner("sacct")
+                sacct_args = ["-o", "state", "-X", "-n", "-j", job_id]
                 status_out = self.sacct_runner.command(*sacct_args, output=str)
-            except ProcessError as e:
-                status_out = ""
+            except (ProcessError, RunnerError, OSError) as e:
                 logger.debug(
                     f"sacct returns error {e}. The status is not resolved correctly."
                 )
@@ -414,13 +421,19 @@ class SlurmRunner:
     def get_partitions(self):
         if self.dry_run:
             return None
-        self._ensure_runner("sinfo")
-        sinfo_args = ["-h"]
-        out = self.sinfo_runner.command(*sinfo_args, output=str).strip()
+        try:
+            self._ensure_runner("sinfo")
+            sinfo_args = ["-h"]
+            out = self.sinfo_runner.command(*sinfo_args, output=str).strip()
+        except (ProcessError, RunnerError, OSError) as e:
+            logger.debug(f"sinfo returns error {e}")
+            return None
         partitions = set()
         default_partition = None
-        for line in out.split("\n"):
+        for line in out.splitlines():
             info = line.split()
+            if not info:
+                continue
             name = info[0].strip()
             if name.endswith("*"):
                 name = name[:-1]

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -13,7 +13,11 @@ from ramble.experiment_result import ExperimentStatus
 from ramble.util import shell_utils
 from ramble.wmkit import *
 
-from spack.util.executable import Executable, ProcessError
+from spack.util.executable import (
+    CommandNotFoundError,
+    Executable,
+    ProcessError,
+)
 
 # Mapping from squeue/sacct status to Ramble status
 _STATUS_MAP = {
@@ -240,7 +244,7 @@ class Slurm(WorkflowManagerBase):
                 job_end_time_str, "%Y-%m-%dT%H:%M:%S"
             ).timestamp()
             duration = int(job_end_time - script_end_time)
-        except (ProcessError, ValueError, OSError) as e:
+        except (ProcessError, ValueError, OSError, CommandNotFoundError) as e:
             logger.warn(f"Failed to get job end time with error {e}")
         else:
             fom_key = "slurm-job-termination-overhead"


### PR DESCRIPTION
Doug hit some issue where he got a bad int cast, this is just to tighten up some safety around that issues

```
    end_time = int(f.read().strip("\n"))
ValueError: invalid literal for int() with base 10: ''
```