### PR TITLE
Migrate unit tests to a dedicated cloud build private pool

### DIFF
--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -103,7 +103,9 @@ substitutions:
   _PYTHON_VER: 3.11.6
   _BASE_IMG: rockylinux
   _BASE_VER: '8'
+  _WORKER_POOL: ''
 timeout: 3600s
 queueTtl: 7200s
 options:
-  machineType: E2_HIGHCPU_8
+  pool:
+    name: '$_WORKER_POOL'

--- a/share/ramble/cloud-build/terraform/triggers/codecov.tf
+++ b/share/ramble/cloud-build/terraform/triggers/codecov.tf
@@ -8,13 +8,12 @@ locals {
 }
 
 resource "google_cloudbuild_trigger" "codecov_pr" {
-  location    = var.region
+  location    = google_cloudbuild_worker_pool.unit_test_pool.location
   name        = "Codecov-PR-Unit-Tests-${local.codecov_image.base}${replace(local.codecov_image.base_ver, ".", "-")}-py${replace(local.codecov_image.python, ".", "-")}-spack${replace(local.codecov_image.spack, ".", "-")}"
   description = "Run unit tests and linting on Ramble pull requests with Codecov upload"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/RambleCI-SA-W1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
@@ -41,17 +40,17 @@ resource "google_cloudbuild_trigger" "codecov_pr" {
     _SPACK_REF     = local.codecov_image.spack
     _PUSH_CODECOV  = "true"
     _CODECOV_TOKEN = data.google_secret_manager_secret_version.codecov_token.secret_data
+    _WORKER_POOL   = google_cloudbuild_worker_pool.unit_test_pool.id
   }
 }
 
 resource "google_cloudbuild_trigger" "codecov_push" {
-  location    = var.region
+  location    = google_cloudbuild_worker_pool.unit_test_pool.location
   name        = "Codecov-BasePush-${local.codecov_image.base}${replace(local.codecov_image.base_ver, ".", "-")}-py${replace(local.codecov_image.python, ".", "-")}-spack${replace(local.codecov_image.spack, ".", "-")}"
   description = "Collect coverage information on develop or main pushes"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/RambleCI-SA-W1/repositories/${var.github_owner}-${var.github_repo}"
     push {
       branch = "(?:main|develop)"
     }
@@ -66,5 +65,6 @@ resource "google_cloudbuild_trigger" "codecov_push" {
     _SPACK_REF     = local.codecov_image.spack
     _PUSH_CODECOV  = "true"
     _CODECOV_TOKEN = data.google_secret_manager_secret_version.codecov_token.secret_data
+    _WORKER_POOL   = google_cloudbuild_worker_pool.unit_test_pool.id
   }
 }

--- a/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
@@ -1,13 +1,23 @@
+resource "google_cloudbuild_worker_pool" "unit_test_pool" {
+  name         = "n2d-unit-test-pool"
+  location     = "southamerica-west1"
+  display_name = "Private N2D worker pool for Ramble unit tests"
+
+  worker_config {
+    machine_type = "n2d-standard-8"
+    disk_size_gb = 100
+  }
+}
+
 resource "google_cloudbuild_trigger" "pr_unit_tests" {
   for_each = local.image_map
 
-  location    = var.region
+  location    = google_cloudbuild_worker_pool.unit_test_pool.location
   name        = "PR-Unit-Tests-${each.value.base}${replace(each.value.base_ver, ".", "-")}-${replace(each.value.spack, ".", "-")}spack-${replace(each.value.python, ".", "-")}python"
   description = "Run unit tests and linting on Ramble pull requests"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/RambleCI-SA-W1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
@@ -29,9 +39,10 @@ resource "google_cloudbuild_trigger" "pr_unit_tests" {
   filename = "share/ramble/cloud-build/ramble-pr-unit-tests.yaml"
 
   substitutions = {
-    _BASE_IMG   = each.value.base
-    _BASE_VER   = each.value.base_ver
-    _PYTHON_VER = each.value.python
-    _SPACK_REF  = each.value.spack
+    _BASE_IMG    = each.value.base
+    _BASE_VER    = each.value.base_ver
+    _PYTHON_VER  = each.value.python
+    _SPACK_REF   = each.value.spack
+    _WORKER_POOL = google_cloudbuild_worker_pool.unit_test_pool.id
   }
 }


### PR DESCRIPTION
We've been seeing more internal errors from the regional (us-central1) default pool, so migrating to use a private pool for these tests. We pick southamerica-west1 as we have the quota.