### PR TITLE
Add compact repo list printing

### DIFF
--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -69,8 +69,8 @@ def setup_parser(subparser):
     list_parser.add_argument(
         "--format",
         choices=["full", "compact"],
-        default="full",
-        help="format to be used to print the output (default: full)",
+        default="compact",
+        help="format to be used to print the output (default: compact)",
     )
     ramble.cmd.common.arguments.add_common_arguments(list_parser, ["repo_type"])
 

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -13,6 +13,7 @@ import sys
 import ramble.cmd.common.arguments
 import ramble.config
 import ramble.repository
+import ramble.util.colors as color
 from ramble.util.logger import logger
 
 description = "manage Ramble repositories"
@@ -64,6 +65,12 @@ def setup_parser(subparser):
         metavar=scopes_metavar,
         default=ramble.config.default_list_scope(),
         help="configuration scope to read from",
+    )
+    list_parser.add_argument(
+        "--format",
+        choices=["full", "compact"],
+        default="full",
+        help="format to be used to print the output (default: full)",
     )
     ramble.cmd.common.arguments.add_common_arguments(list_parser, ["repo_type"])
 
@@ -312,6 +319,34 @@ def repo_remove(args):
         )
 
 
+def format_types(types_list):
+    """Summarize a list of object types compactly."""
+    if not types_list:
+        return "none"
+
+    all_obj_types = list(ramble.repository.ObjectTypes)
+    all_type_names = {obj_type.name for obj_type in all_obj_types}
+    non_util_type_names = {
+        obj_type.name for obj_type in all_obj_types if "util" not in obj_type.name
+    }
+
+    types_set = set(types_list)
+    if types_set == all_type_names:
+        return "all"
+    if types_set == non_util_type_names:
+        return "all (non-utility)"
+    if len(types_list) <= 3:
+        return ", ".join(types_list)
+    abbrevs = [
+        ramble.repository.type_definitions[ramble.repository.ObjectTypes[t]]["abbrev"]
+        for t in types_list
+    ]
+    abbrev_str = ", ".join(abbrevs)
+    if len(abbrev_str) <= 35:
+        return abbrev_str
+    return f"{len(types_list)} types"
+
+
 def repo_list(args):
     """Show registered repositories and their namespaces."""
     if args.type == "any":
@@ -319,32 +354,93 @@ def repo_list(args):
     else:
         obj_types = [ramble.repository.ObjectTypes[args.type]]
 
-    total_repos = 0
-    for obj_type in obj_types:
-        type_def = ramble.repository.type_definitions[obj_type]
+    is_compact = args.format == "compact"
 
-        roots = ramble.config.get(type_def["config_section"], scope=args.scope)
-        repos = []
-        for r in roots:
-            try:
-                repos.append(ramble.repository.Repo(r, obj_type))
-            except ramble.repository.RepoError:
+    total_repos = 0
+
+    if is_compact:
+        repos_data = {}
+        for obj_type in obj_types:
+            type_def = ramble.repository.type_definitions[obj_type]
+
+            roots = ramble.config.get(type_def["config_section"], scope=args.scope) or []
+            for r in roots:
+                try:
+                    repo = ramble.repository.Repo(r, obj_type)
+                except ramble.repository.RepoError:
+                    continue
+
+                key = repo.root
+                if key not in repos_data:
+                    repos_data[key] = {
+                        "namespace": repo.namespace,
+                        "root": repo.root,
+                        "types": [],
+                    }
+                if obj_type.name not in repos_data[key]["types"]:
+                    repos_data[key]["types"].append(obj_type.name)
+
+        total_repos = len(repos_data)
+
+        if repos_data:
+            if sys.stdout.isatty():
+                type_context = "" if args.type == "any" else f"{args.type} "
+                msg = f"{total_repos} {type_context}repositor"
+                msg += "y." if total_repos == 1 else "ies."
+                logger.msg(msg)
+
+            rows = []
+            for d in repos_data.values():
+                t_str = format_types(d["types"])
+                rows.append((d["namespace"], t_str, d["root"]))
+
+            rows.sort(key=lambda r: (r[0].lower(), r[2]))
+
+            header_ns = "NAMESPACE"
+            header_t = "TYPES"
+            header_p = "PATH"
+
+            max_ns = max([len(header_ns)] + [len(r[0]) for r in rows])
+            max_t = max([len(header_t)] + [len(r[1]) for r in rows])
+
+            header_line = (
+                f"{color.section_title(f'{header_ns:<{max_ns}}')}  "
+                f"{color.section_title(f'{header_t:<{max_t}}')}  "
+                f"{color.section_title(header_p)}"
+            )
+            color.cprint(header_line)
+
+            for ns, t, path in rows:
+                ns_padded = f"{ns:<{max_ns}}"
+                t_padded = f"{t:<{max_t}}"
+                row_line = f"{color.nested_1(ns_padded)}  {t_padded}  {path}"
+                color.cprint(row_line)
+    else:
+        for obj_type in obj_types:
+            type_def = ramble.repository.type_definitions[obj_type]
+
+            roots = ramble.config.get(type_def["config_section"], scope=args.scope)
+            repos = []
+            for r in roots:
+                try:
+                    repos.append(ramble.repository.Repo(r, obj_type))
+                except ramble.repository.RepoError:
+                    continue
+
+            total_repos += len(repos)
+
+            if sys.stdout.isatty() and repos:
+                msg = f"{len(repos)} {obj_type.name} repositor"
+                msg += "y." if len(repos) == 1 else "ies."
+                logger.msg(msg)
+
+            if not repos:
                 continue
 
-        total_repos += len(repos)
-
-        if sys.stdout.isatty() and repos:
-            msg = f"{len(repos)} {obj_type.name} repositor"
-            msg += "y." if len(repos) == 1 else "ies."
-            logger.msg(msg)
-
-        if not repos:
-            continue
-
-        max_ns_len = max(len(r.namespace) for r in repos)
-        for repo in repos:
-            fmt = "%%-%ds%%s" % (max_ns_len + 4)
-            print(fmt % (repo.namespace, repo.root))
+            max_ns_len = max(len(r.namespace) for r in repos)
+            for repo in repos:
+                fmt = "%%-%ds%%s" % (max_ns_len + 4)
+                print(fmt % (repo.namespace, repo.root))
 
     if total_repos == 0:
         scope_str = f" in scope '{args.scope}'" if args.scope else ""

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -7,9 +7,14 @@
 # except according to those terms.
 import os
 import shutil
+from types import SimpleNamespace
 
 import pytest
 
+import ramble.cmd.repo
+import ramble.config
+import ramble.repository
+from ramble.cmd.repo import format_types
 from ramble.error import RambleCommandError
 from ramble.main import RambleCommand
 from ramble.repository import BadRepoError
@@ -239,20 +244,32 @@ def test_repo_list_compact(mutable_config, tmpdir):
     assert output.count("compact_ns") == 1
 
 
-def test_repo_list_full_format_is_unchanged(mutable_config, tmpdir):
-    """The full (default) format should not print the compact table headers."""
+def test_repo_list_compact_is_the_default(mutable_config, tmpdir):
+    """Bare `repo list` uses the compact format."""
+    repo_path = str(tmpdir.join("default_repo"))
+    repo("create", repo_path, "default_ns")
+    repo("add", "--scope=site", repo_path)
+
+    implicit = repo("list", output=str)
+    explicit = repo("list", "--format=compact", output=str)
+
+    assert implicit == explicit
+    assert "NAMESPACE" in implicit
+    assert implicit.count("default_ns") == 1
+
+
+def test_repo_list_full_format_still_available(mutable_config, tmpdir):
+    """The full format keeps the original per-type listing."""
     repo_path = str(tmpdir.join("full_repo"))
     repo("create", repo_path, "full_ns")
     repo("add", "--scope=site", repo_path)
 
-    implicit = repo("list", output=str)
-    explicit = repo("list", "--format=full", output=str)
+    output = repo("list", "--format=full", output=str)
 
-    assert implicit == explicit
-    assert "NAMESPACE" not in implicit
-    assert "full_ns" in implicit
+    assert "NAMESPACE" not in output
+    assert "full_ns" in output
     # The repo is registered for every object type, so it repeats in this format
-    assert implicit.count("full_ns") > 1
+    assert output.count("full_ns") > 1
 
 
 def test_repo_list_compact_specific_type(mutable_config, tmpdir):
@@ -272,3 +289,90 @@ def test_repo_list_compact_empty(mutable_empty_config):
     output = repo("list", "--format=compact", output=str)
     assert repo.returncode == 0
     assert "No repositories found" in output
+
+
+@pytest.mark.parametrize(
+    "types_list,expected",
+    [
+        # An empty list should never reach the summarizer, but guard against it anyway
+        ([], "none"),
+        # Three or fewer types are spelled out in full
+        (["applications"], "applications"),
+        (["applications", "modifiers"], "applications, modifiers"),
+        (
+            ["applications", "modifiers", "package_managers"],
+            "applications, modifiers, package_managers",
+        ),
+        # Four or more types switch to abbreviations to keep the column narrow
+        (
+            ["applications", "modifiers", "package_managers", "workflow_managers"],
+            "app, mod, pkg_man, wm",
+        ),
+        # Once the abbreviations grow too wide, fall back to a bare count
+        (
+            [
+                "applications",
+                "modifiers",
+                "package_managers",
+                "workflow_managers",
+                "systems",
+                "platforms",
+                "base_classes",
+            ],
+            "7 types",
+        ),
+    ],
+)
+def test_format_types(types_list, expected):
+    assert format_types(types_list) == expected
+
+
+def test_format_types_all():
+    """A repo registered for every object type collapses to 'all'."""
+    all_types = [obj_type.name for obj_type in ramble.repository.ObjectTypes]
+    assert format_types(all_types) == "all"
+
+
+def test_format_types_all_non_utility():
+    """Utility types are commonly absent, so that case gets its own label."""
+    non_utility = [
+        obj_type.name for obj_type in ramble.repository.ObjectTypes if "util" not in obj_type.name
+    ]
+    assert format_types(non_utility) == "all (non-utility)"
+
+
+def test_repo_list_compact_skips_invalid_repos(mutable_config, tmpdir):
+    """A stale path in the config is skipped instead of failing the listing."""
+    valid_path = str(tmpdir.join("valid_repo"))
+    repo("create", valid_path, "valid_ns")
+    repo("add", "--scope=site", valid_path)
+
+    missing_path = str(tmpdir.join("does_not_exist"))
+    roots = ramble.config.get("repos", scope="site")
+    ramble.config.set("repos", syaml.syaml_list([missing_path] + list(roots)), scope="site")
+
+    output = repo("list", "--format=compact", output=str)
+    assert repo.returncode == 0
+    assert missing_path not in output
+    assert "valid_ns" in output
+
+
+@pytest.mark.parametrize("fmt", ["full", "compact"])
+@pytest.mark.parametrize("type_args", [[], ["-t", "applications"]])
+def test_repo_list_summary_only_on_tty(mutable_config, tmpdir, monkeypatch, type_args, fmt):
+    """The count summary is written for interactive use, but kept out of pipes."""
+    repo_path = str(tmpdir.join("tty_repo"))
+    repo("create", repo_path, "tty_ns")
+    repo("add", "--scope=site", repo_path)
+
+    piped = repo("list", *type_args, f"--format={fmt}", output=str)
+    assert "repositor" not in piped
+
+    # Only repo.py's view of sys is replaced, so output capture is left intact
+    monkeypatch.setattr(
+        ramble.cmd.repo, "sys", SimpleNamespace(stdout=SimpleNamespace(isatty=lambda: True))
+    )
+
+    on_tty = repo("list", *type_args, f"--format={fmt}", output=str)
+    assert "repositor" in on_tty
+    assert "tty_ns" in on_tty

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -221,3 +221,54 @@ def test_repo_list_no_results_warning(mutable_empty_config):
     out = repo("list", "--scope=site", output=str)
     assert repo.returncode == 0
     assert "No repositories found in scope 'site'" in out
+
+
+def test_repo_list_compact(mutable_config, tmpdir):
+    repo_path = str(tmpdir.join("compact_repo"))
+    repo("create", repo_path, "compact_ns")
+    repo("add", "--scope=site", repo_path)
+
+    output = repo("list", "--format=compact", output=str)
+
+    assert "NAMESPACE" in output
+    assert "TYPES" in output
+    assert "PATH" in output
+    assert "compact_ns" in output
+
+    # Ensure the repo appears only once in the compact output
+    assert output.count("compact_ns") == 1
+
+
+def test_repo_list_full_format_is_unchanged(mutable_config, tmpdir):
+    """The full (default) format should not print the compact table headers."""
+    repo_path = str(tmpdir.join("full_repo"))
+    repo("create", repo_path, "full_ns")
+    repo("add", "--scope=site", repo_path)
+
+    implicit = repo("list", output=str)
+    explicit = repo("list", "--format=full", output=str)
+
+    assert implicit == explicit
+    assert "NAMESPACE" not in implicit
+    assert "full_ns" in implicit
+    # The repo is registered for every object type, so it repeats in this format
+    assert implicit.count("full_ns") > 1
+
+
+def test_repo_list_compact_specific_type(mutable_config, tmpdir):
+    repo_path = str(tmpdir.join("app_only_repo"))
+    repo("create", repo_path, "app_ns", "-t", "applications")
+    repo("add", "-t", "applications", "--scope=site", repo_path)
+
+    output = repo("list", "-t", "applications", "--format=compact", output=str)
+    assert "NAMESPACE" in output
+    assert "TYPES" in output
+    assert "PATH" in output
+    assert "app_ns" in output
+    assert output.count("app_ns") == 1
+
+
+def test_repo_list_compact_empty(mutable_empty_config):
+    output = repo("list", "--format=compact", output=str)
+    assert repo.returncode == 0
+    assert "No repositories found" in output

--- a/share/ramble/bash/ramble-completion.in
+++ b/share/ramble/bash/ramble-completion.in
@@ -149,7 +149,7 @@ _all_applications() {
 _repos() {
     if [[ -z "${RAMBLE_REPOS:-}" ]]
     then
-        RAMBLE_REPOS="$(ramble repo list | awk '{print $1}')"
+        RAMBLE_REPOS="$(ramble repo list --format=compact | tail -n +2 | awk '{print $1}')"
     fi
     RAMBLE_COMPREPLY="$RAMBLE_REPOS"
 }

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -584,7 +584,7 @@ _ramble_repo_create() {
 }
 
 _ramble_repo_list() {
-    RAMBLE_COMPREPLY="-h --help --scope -t --type"
+    RAMBLE_COMPREPLY="-h --help --scope --format -t --type"
 }
 
 _ramble_repo_add() {

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -149,7 +149,7 @@ _all_applications() {
 _repos() {
     if [[ -z "${RAMBLE_REPOS:-}" ]]
     then
-        RAMBLE_REPOS="$(ramble repo list | awk '{print $1}')"
+        RAMBLE_REPOS="$(ramble repo list --format=compact | tail -n +2 | awk '{print $1}')"
     fi
     RAMBLE_COMPREPLY="$RAMBLE_REPOS"
 }


### PR DESCRIPTION
The existing format is great but gets very long:

```
==> 4 applications repositories.
builtin.mock    /Users/robertbird/ramble/injconf/var/ramble/repos/builtin.mock
extra       /Users/robertbird/extra
builtin         /Users/robertbird/ramble/var/ramble/repos/builtin
==> 4 modifiers repositories.
builtin.mock    /Users/robertbird/ramble/injconf/var/ramble/repos/builtin.mock
builtin         /Users/robertbird/ramble/var/ramble/repos/builtin
==> 3 package_managers repositories.
extra      /Users/robertbird/extra
builtin        /Users/robertbird/ramble/var/ramble/repos/builtin
==> 3 workflow_managers repositories.
extra      /Users/robertbird/extra
builtin        /Users/robertbird/ramble/var/ramble/repos/builtin
==> 3 systems repositories.
...
```

This offers a compact alternative:
```
 $ ramble repo list --format=compact
==> 4 repositories.
NAMESPACE     TYPES                    PATH
builtin       all                      /Users/robertbird/ramble/var/ramble/repos/builtin
builtin.mock  applications, modifiers  /Users/robertbird/ramble/injconf/var/ramble/repos/builtin.mock
extra     all (non-utility)        /Users/robertbird/extra
```

Flips the default output to compact, as requested