### PR TITLE
Standarize return code for `list` commands

### DIFF
--- a/lib/ramble/ramble/cmd/attributes.py
+++ b/lib/ramble/ramble/cmd/attributes.py
@@ -92,7 +92,12 @@ def objects_to_attributes(
 
     app_to_users = defaultdict(set)
     for name in object_names:
-        cls = ramble.repository.paths[object_type].get_obj_class(name)
+        if not ramble.repository.paths[object_type].exists(name):
+            continue
+        try:
+            cls = ramble.repository.paths[object_type].get_obj_class(name)
+        except Exception:
+            continue
         for user in getattr(cls, attr_name):
             app_to_users[name].add(user)
 
@@ -106,7 +111,10 @@ def attributes_to_objects(
     lower_users = {u.lower() for u in users} if users else set()
     object_names = ramble.repository.paths[object_type].all_object_names()
     for name in object_names:
-        cls = ramble.repository.paths[object_type].get_obj_class(name)
+        try:
+            cls = ramble.repository.paths[object_type].get_obj_class(name)
+        except Exception:
+            continue
         for user in getattr(cls, attr_name):
             if not users or user.lower() in lower_users:
                 user_to_apps[user].append(cls.name)
@@ -119,7 +127,10 @@ def defined_objects(attr_name=default_attr, object_type=ramble.repository.defaul
     undefined = []
     object_names = ramble.repository.paths[object_type].all_object_names()
     for name in object_names:
-        cls = ramble.repository.paths[object_type].get_obj_class(name)
+        try:
+            cls = ramble.repository.paths[object_type].get_obj_class(name)
+        except Exception:
+            continue
         if hasattr(cls, attr_name) and getattr(cls, attr_name):
             defined.append(name)
         else:
@@ -153,25 +164,35 @@ def attributes(parser, args):
     if args.defined or args.undefined:
         defined, undefined = defined_objects(attr_name=attr_name, object_type=object_type)
         apps = defined if args.defined else undefined
-        colify(apps)
-        return 0 if apps else 1
+        if not apps:
+            mode_str = "defined" if args.defined else "undefined"
+            logger.warn(f"No {object_type.name} found with {attr_name} {mode_str}.")
+        else:
+            colify(apps)
+        return 0
 
     if args.all:
         if args.by_attribute:
             attributes = attributes_to_objects(
                 args.object_or_attr, attr_name=attr_name, object_type=object_type
             )
-            for user, objects in sorted(attributes.items()):
-                color.cprint(f"@c{{{user}}}: {', '.join(sorted(objects))}")
-            return 0 if attributes else 1
+            if not attributes:
+                logger.warn(f"No {attr_name} found for any {object_type.name}.")
+            else:
+                for user, objects in sorted(attributes.items()):
+                    color.cprint(f"@c{{{user}}}: {', '.join(sorted(objects))}")
+            return 0
 
         else:
             objects = objects_to_attributes(
                 args.object_or_attr, attr_name=attr_name, object_type=object_type
             )
-            for app, attributes in sorted(objects.items()):
-                color.cprint(f"@c{{{app}}}: {', '.join(sorted(attributes))}")
-            return 0 if objects else 1
+            if not objects:
+                logger.warn(f"No {object_type.name} found with {attr_name}.")
+            else:
+                for app, attributes in sorted(objects.items()):
+                    color.cprint(f"@c{{{app}}}: {', '.join(sorted(attributes))}")
+            return 0
 
     if args.by_attribute:
         if not args.object_or_attr:
@@ -182,17 +203,35 @@ def attributes(parser, args):
                 args.object_or_attr, attr_name=attr_name, object_type=object_type
             )
         )
-        colify(objects)
-        return 0 if objects else 1
+        if not objects:
+            attrs_str = ", ".join(args.object_or_attr)
+            logger.warn(f"No {object_type.name} found with {attr_name} '{attrs_str}'.")
+        else:
+            colify(objects)
+        return 0
 
     else:
         if not args.object_or_attr:
             logger.die("ramble attributes requires an object or --all")
+
+        missing = [
+            obj
+            for obj in args.object_or_attr
+            if not ramble.repository.paths[object_type].exists(obj)
+        ]
+        if missing:
+            objs_str = ", ".join(f"'{o}'" for o in missing)
+            logger.error(f"Object {objs_str} not found in {object_type.name} repository.")
+            return 1
 
         users = union_values(
             objects_to_attributes(
                 args.object_or_attr, attr_name=attr_name, object_type=object_type
             )
         )
-        colify(users)
-        return 0 if users else 1
+        if not users:
+            objs_str = ", ".join(args.object_or_attr)
+            logger.warn(f"No {attr_name} found for {object_type.name} '{objs_str}'.")
+        else:
+            colify(users)
+        return 0

--- a/lib/ramble/ramble/cmd/common/list.py
+++ b/lib/ramble/ramble/cmd/common/list.py
@@ -172,12 +172,24 @@ def perform_list(args):
         sorted_objects = set(sorted_objects) & objects_with_tags
         sorted_objects = sorted(sorted_objects)
 
+    if not sorted_objects:
+        filter_strs = []
+        if args.filter:
+            filter_strs.append(f"filter '{' '.join(args.filter)}'")
+        if args.tags:
+            filter_strs.append(f"tags '{', '.join(args.tags)}'")
+        if filter_strs:
+            logger.warn(f"No {object_type.name} found matching {' and '.join(filter_strs)}.")
+        else:
+            logger.warn(f"No {object_type.name} found.")
+        return 0
+
     if args.update:
         # change output stream if user asked for update
         if os.path.exists(args.update):
             if os.path.getmtime(args.update) > ramble.repository.paths[object_type].last_mtime():
                 logger.msg(f"File is up to date: {args.update}")
-                return
+                return 0
 
         logger.msg(f"Updating file: {args.update}")
         with open(args.update, "w", encoding="utf-8") as f:
@@ -186,3 +198,5 @@ def perform_list(args):
     else:
         # Print to stdout
         formatter(sorted_objects, sys.stdout, object_type)
+
+    return 0

--- a/lib/ramble/ramble/cmd/filter_groups.py
+++ b/lib/ramble/ramble/cmd/filter_groups.py
@@ -79,15 +79,15 @@ def filter_groups(parser, args):
         return
 
     if action == "list":
-        filter_groups_list(args)
+        return filter_groups_list(args)
     elif action == "blame":
-        filter_groups_blame(args)
+        return filter_groups_blame(args)
     else:
         scope = _resolve_scope(args, default_scope="user")
         if action == "add":
-            filter_groups_add(scope, args)
+            return filter_groups_add(scope, args)
         elif action in ("remove", "rm"):
-            filter_groups_remove(scope, args)
+            return filter_groups_remove(scope, args)
 
 
 def filter_groups_add(scope, args):
@@ -159,8 +159,8 @@ def print_filter_groups(resolved_scope_name=None, original_scope_name=None, verb
                     {"scope": display_name, "name": name, "definition": definition}
                 )
         else:
-            logger.msg(f"No filter groups defined in scope '{original_scope_name}'.")
-            return
+            logger.warn(f"No filter groups defined in scope '{original_scope_name}'.")
+            return 0
     else:
         for scope in ramble.config.config:
             try:
@@ -177,8 +177,8 @@ def print_filter_groups(resolved_scope_name=None, original_scope_name=None, verb
                 pass
 
     if not groups_to_print:
-        logger.msg("No filter groups defined.")
-        return
+        logger.warn("No filter groups defined.")
+        return 0
 
     if verbose:
         current_scope = None
@@ -228,6 +228,8 @@ def print_filter_groups(resolved_scope_name=None, original_scope_name=None, verb
             )
             colify(names, **colify_opts)
 
+    return 0
+
 
 def filter_groups_list(args):
     verbose = getattr(args, "verbose", False)
@@ -235,7 +237,7 @@ def filter_groups_list(args):
     if args.scope is not None:
         resolved_scope_name = _resolve_scope(args)
 
-    print_filter_groups(
+    return print_filter_groups(
         resolved_scope_name=resolved_scope_name,
         original_scope_name=args.scope,
         verbose=verbose,

--- a/lib/ramble/ramble/cmd/list.py
+++ b/lib/ramble/ramble/cmd/list.py
@@ -18,4 +18,4 @@ def setup_parser(subparser):
 
 
 def list(parser, args):
-    ramble.cmd.common.list.perform_list(args)
+    return ramble.cmd.common.list.perform_list(args)

--- a/lib/ramble/ramble/cmd/mirror.py
+++ b/lib/ramble/ramble/cmd/mirror.py
@@ -164,10 +164,11 @@ def mirror_list(args):
 
     mirrors = ramble.mirror.MirrorCollection(scope=args.scope)
     if not mirrors:
-        logger.msg("No mirrors configured.")
-        return
+        logger.warn("No mirrors configured.")
+        return 0
 
     mirrors.display()
+    return 0
 
 
 def mirror_destroy(args):
@@ -196,4 +197,4 @@ def mirror(parser, args):
     if args.no_checksum:
         ramble.config.set("config:checksum", False, scope="command_line")
 
-    action[args.mirror_command](args)
+    return action[args.mirror_command](args)

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -326,6 +326,7 @@ def repo_list(args):
     else:
         obj_types = [ramble.repository.ObjectTypes[args.type]]
 
+    total_repos = 0
     for obj_type in obj_types:
         type_def = ramble.repository.type_definitions[obj_type]
 
@@ -337,7 +338,9 @@ def repo_list(args):
             except ramble.repository.RepoError:
                 continue
 
-        if sys.stdout.isatty():
+        total_repos += len(repos)
+
+        if sys.stdout.isatty() and repos:
             msg = f"{len(repos)} {obj_type.name} repositor"
             msg += "y." if len(repos) == 1 else "ies."
             logger.msg(msg)
@@ -349,6 +352,15 @@ def repo_list(args):
         for repo in repos:
             fmt = "%%-%ds%%s" % (max_ns_len + 4)
             print(fmt % (repo.namespace, repo.root))
+
+    if total_repos == 0:
+        scope_str = f" in scope '{args.scope}'" if args.scope else ""
+        if args.type == "any":
+            logger.warn(f"No repositories found{scope_str}.")
+        else:
+            logger.warn(f"No {args.type} repositories found{scope_str}.")
+
+    return 0
 
 
 def repo(parser, args):
@@ -363,4 +375,4 @@ def repo(parser, args):
     if args.type != "any":
         args.type = ramble.repository.simplify_object_type(args.type).name
 
-    action[args.repo_command](args)
+    return action[args.repo_command](args)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1184,14 +1184,16 @@ def workspace_list(args):
                 name = color.colorize(f"@*g{{{name}}}")
             color_names.append(name)
 
+        if not names:
+            logger.warn("No workspaces found.")
+            return 0
+
         # say how many there are if writing to a tty
         if sys.stdout.isatty():
-            if not names:
-                logger.msg("No workspaces")
-            else:
-                logger.msg(f"{len(names)} workspaces")
+            logger.msg(f"{len(names)} workspaces")
 
         colify(color_names, indent=4)
+        return 0
     else:
         if args.parent_dir:
             wspaths = ramble.workspace.get_workspace_path()
@@ -1204,11 +1206,13 @@ def workspace_list(args):
         else:
             wspaths = ramble.workspace.get_workspace_path()
 
+        total_workspaces = 0
         for i, wspath in enumerate(wspaths):
             if i > 0:
                 color.cprint("")
             color.cprint(color.section_title("Workspaces from dir:") + " " + wspath)
             names = ramble.workspace.all_workspace_names(parent_dir=wspath)
+            total_workspaces += len(names)
 
             color_names = []
             for name in names:
@@ -1217,13 +1221,15 @@ def workspace_list(args):
                 color_names.append(name)
 
             # say how many there are if writing to a tty
-            if sys.stdout.isatty():
-                if not names:
-                    logger.msg("No workspaces")
-                else:
-                    logger.msg(f"{len(names)} workspaces")
+            if sys.stdout.isatty() and names:
+                logger.msg(f"{len(names)} workspaces")
 
             colify(color_names, indent=4)
+
+        if total_workspaces == 0:
+            logger.warn("No workspaces found.")
+
+        return 0
 
 
 def workspace_edit_setup_parser(subparser):

--- a/lib/ramble/ramble/test/cmd/attributes.py
+++ b/lib/ramble/ramble/test/cmd/attributes.py
@@ -135,3 +135,30 @@ def test_mock_attributes_list(
 
     for obj in unexpected_objs:
         assert obj not in out_list
+
+
+def test_attributes_no_results_warning():
+    out = attributes("nonexistent_app_name_xyz", fail_on_error=False)
+    assert attributes.returncode == 1
+    assert "Object 'nonexistent_app_name_xyz' not found in applications repository" in out
+
+    out = attributes("--modifiers", "nonexistent_mod_name_xyz", fail_on_error=False)
+    assert attributes.returncode == 1
+    assert "Object 'nonexistent_mod_name_xyz' not found in modifiers repository" in out
+
+    out = attributes("--by-attribute", "nonexistent_attr_xyz")
+    assert attributes.returncode == 0
+    assert "No applications found with maintainers 'nonexistent_attr_xyz'" in out
+
+    out = attributes("--tags", "--by-attribute", "nonexistent_tag_xyz")
+    assert attributes.returncode == 0
+    assert "No applications found with tags 'nonexistent_tag_xyz'" in out
+
+
+def test_attributes_unmaintained_object_warning(
+    mutable_mock_apps_repo,
+    mock_applications,
+):
+    out = attributes("unmaintained-1")
+    assert attributes.returncode == 0
+    assert "No maintainers found for applications 'unmaintained-1'" in out

--- a/lib/ramble/ramble/test/cmd/list.py
+++ b/lib/ramble/ramble/test/cmd/list.py
@@ -124,3 +124,23 @@ def test_list_update(tmpdir):
     assert update_file.exists()
     with update_file.open() as f:
         assert f.read() == "empty\n"
+
+
+def test_list_no_results_warning():
+    out = list("nonexistent_app_name_xyz")
+    assert list.returncode == 0
+    assert "No applications found matching filter 'nonexistent_app_name_xyz'" in out
+
+    out = list("--tags", "nonexistent_tag_xyz")
+    assert list.returncode == 0
+    assert "No applications found matching tags 'nonexistent_tag_xyz'" in out
+
+    out = list("--type", "modifiers", "nonexistent_mod_xyz")
+    assert list.returncode == 0
+    assert "No modifiers found matching filter 'nonexistent_mod_xyz'" in out
+
+    out = list("--tags", "nonexistent_tag", "nonexistent_app")
+    assert list.returncode == 0
+    assert (
+        "No applications found matching filter 'nonexistent_app' and tags 'nonexistent_tag'" in out
+    )

--- a/lib/ramble/ramble/test/cmd/mirror.py
+++ b/lib/ramble/ramble/test/cmd/mirror.py
@@ -58,6 +58,12 @@ def test_mirror_nonexisting(tmp_scope):
         mirror("set-url", "--scope", tmp_scope, "not-a-mirror", "http://ramble.io")
 
 
+def test_mirror_list_empty(tmp_scope):
+    out = mirror("list", "--scope", tmp_scope)
+    assert mirror.returncode == 0
+    assert "No mirrors configured." in out
+
+
 def test_mirror_add(tmp_scope):
     mirror("add", "--scope", tmp_scope, "first", "my.url.com")
 

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -207,3 +207,17 @@ def test_repo_list_multitype_non_application_scope(mutable_empty_config, tmpdir)
 
     output = repo("list", output=str)
     assert "mockmodrepo" in output
+
+
+def test_repo_list_no_results_warning(mutable_empty_config):
+    out = repo("list", output=str)
+    assert repo.returncode == 0
+    assert "No repositories found" in out
+
+    out = repo("list", "-t", "modifiers", output=str)
+    assert repo.returncode == 0
+    assert "No modifiers repositories found" in out
+
+    out = repo("list", "--scope=site", output=str)
+    assert repo.returncode == 0
+    assert "No repositories found in scope 'site'" in out

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -261,6 +261,16 @@ def test_workspace_list(mutable_mock_workspace_path):
     assert ".DS_Store" not in out
 
 
+def test_workspace_list_empty(mutable_mock_workspace_path):
+    out = workspace("list")
+    assert workspace.returncode == 0
+    assert "No workspaces found." in out
+
+    out = workspace("list", "--merged")
+    assert workspace.returncode == 0
+    assert "No workspaces found." in out
+
+
 def test_workspace_info(workspace_name):
     global_args = ["-w", workspace_name]
     ws1 = ramble.workspace.create(workspace_name)


### PR DESCRIPTION
Also adds a warning on stderr for searches that come back empty

The main change is in `ramble attributes` which used to crash with no message