### PR TITLE
fix python 3.6 support 

### DIFF
--- a/lib/ramble/llnl/util/filesystem.py
+++ b/lib/ramble/llnl/util/filesystem.py
@@ -55,7 +55,12 @@ else:
     try:
         from typing_extensions import Literal
     except ImportError:
-        Literal = Any  # type: ignore[misc]
+
+        class _Literal:
+            def __getitem__(self, item):
+                return Any
+
+        Literal = _Literal()  # type: ignore[misc]
 
 from llnl.path import path_to_os_path, sanitize_win_longpath, system_path_filter
 from llnl.util import lang, tty

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,6 @@ pytest-xdist
 pytest-clarity
 line_profiler
 isort
-codecov-cli
+codecov-cli;python_version>="3.9"
 mypy
-ruff
+ruff;python_version>="3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ graphlib-backport;python_version<"3.9"
 urllib3==1.26.18;python_version<="3.6"
 protobuf;python_version>"3.6"
 protobuf==3.19.4;python_version<="3.6"
-pyarrow==3.0.0;python_version<="3.6"
-google-cloud-bigquery
+google-cloud-bigquery;python_version>"3.6"
+google-cloud-bigquery<3;python_version<="3.6"
 tqdm
 deprecation
 pandas


### PR DESCRIPTION
Some older VMs might need either a pip update:

```
python3 -m pip install --upgrade "pip<22"
```
and/or to make sure the right header packages are installed if wheels are not available:

```
sudo yum install python3-devel
sudo yum install libjpeg-turbo-devel
```