### PR TITLE
Split out standard variants from reserved

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -1326,7 +1326,7 @@ def variant(
             description (str): Description of the variant
             values: Values for variant.
         """
-        ramble.variants.validate_variant(name)
+        ramble.variants.validate_variant(name, values=values, default=default)
 
         args_dict = {
             "name": name,

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -675,16 +675,23 @@ def test_containerized_reserved_variant(request):
         # Verify it validates correctly without errors
         workspace("concretize", global_args=global_args)
 
-        # Verify containerized is in reserved_variants and validate_variant raises an error
-        # for custom definitions, but works for the workspace.
+        # Verify reserved variants raise an error, while standard variants are permitted
         with pytest.raises(ramble.variants.RambleVariantError):
-            ramble.variants.validate_variant("containerized")
+            ramble.variants.validate_variant("workflow_manager")
+
+        assert "containerized" in ramble.variants.standard_variants
+        ramble.variants.validate_variant("containerized")
+        ramble.variants.validate_variant("containerized", default=True, values=(True, False))
+
+        with pytest.raises(ramble.variants.RambleVariantError):
+            ramble.variants.validate_variant("containerized", values=["invalid_value"])
 
         # Verify that containerized is false by default in workspace config context
         # (It should load from etc/ramble/defaults/variants.yaml)
         exp_set = ws.build_experiment_set()
         for _, app, _ in exp_set.all_experiments():
             assert not app.object_variants.value("containerized")
+            assert not app.experiment_variants().value("containerized")
 
         # Set it to true in workspace config and verify
         config("add", "variants:containerized:true", global_args=global_args)
@@ -692,6 +699,7 @@ def test_containerized_reserved_variant(request):
         exp_set = ws.build_experiment_set()
         for _, app, _ in exp_set.all_experiments():
             assert app.object_variants.value("containerized")
+            assert app.experiment_variants().value("containerized")
 
 
 def test_workflow_manager_containerized_propagation(request):
@@ -728,14 +736,85 @@ def test_workflow_manager_containerized_propagation(request):
         # Verify it defaults to containerized=True
         exp_set = ws.build_experiment_set()
         for _, app, _ in exp_set.all_experiments():
-            assert app.object_variants.value("containerized")
+            assert app.experiment_variants().value("containerized")
 
         # Now set it explicitly to false, and verify it respects the user override
         config("add", "variants:containerized:false", global_args=global_args)
         ws._re_read()
         exp_set = ws.build_experiment_set()
         for _, app, _ in exp_set.all_experiments():
-            assert not app.object_variants.value("containerized")
+            assert not app.experiment_variants().value("containerized")
+
+
+def test_modifier_containerized_propagation(request, mock_modifiers, mock_base_modifiers):
+    mock_modifiers.put_first(
+        ramble.repository.Repo(ramble.paths.builtin_path, ramble.repository.ObjectTypes.modifiers)
+    )
+    mock_base_modifiers.put_first(
+        ramble.repository.Repo(
+            ramble.paths.builtin_path, ramble.repository.ObjectTypes.base_modifiers
+        )
+    )
+    ws_name = request.node.name
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+        # Define mpi_command and container_uri variables
+        config("add", "variables:mpi_command:mpirun -n {n_ranks}", global_args=global_args)
+        config("add", "variables:container_uri:fake-uri", global_args=global_args)
+
+        # By default, user-managed workflow manager without container
+        # modifier has containerized=False
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert not app.experiment_variants().value("containerized")
+            assert "container_only_var" not in app.variables
+
+        # Add docker modifier (inherits containerized=True from container-base)
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "-s",
+            "workspace",
+            "-n",
+            "docker",
+            global_args=global_args,
+        )
+        ws._re_read()
+
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert app.experiment_variants().value("containerized")
+            assert "container_only_var" in app.variables
+
+        # Explicit user override variants:containerized:false takes precedence
+        config("add", "variants:containerized:false", global_args=global_args)
+        ws._re_read()
+
+        exp_set = ws.build_experiment_set()
+        for _, app, _ in exp_set.all_experiments():
+            assert not app.experiment_variants().value("containerized")
+            assert "container_only_var" not in app.variables
 
 
 def test_containerized_app_variable_guarding(request):

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -9,7 +9,7 @@
 import functools
 from collections.abc import Sequence
 from enum import Enum
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import ramble.error
 import ramble.util.colors as color
@@ -29,7 +29,14 @@ reserved_variants = {
     "is_repeat_child",
     "is_repeat_parent",
     "repeat_index",
-    "containerized",
+}
+
+standard_variants: Dict[str, Dict[str, Any]] = {
+    "containerized": {
+        "default": False,
+        "values": (True, False),
+        "description": "Whether this experiment is run inside a container",
+    },
 }
 
 variant_types = Enum("variant_types", ["default", "experiment", "version"])
@@ -133,6 +140,14 @@ class VariantSet:
             if name not in self.default_variants:
                 self.default_variants[name] = variant.copy()
                 mutated = True
+            elif name in standard_variants:
+                std_default = standard_variants[name].get("default", False)
+                if (
+                    variant.default != std_default
+                    and self.default_variants[name].default == std_default
+                ):
+                    self.default_variants[name] = variant.copy()
+                    mutated = True
         return mutated
 
     @invalidates_cache
@@ -233,23 +248,19 @@ class VariantSet:
         if default_var and isinstance(default_var.default, (bool, syaml_bool)):
             if isinstance(value, str):
                 value = value.lower() == "true"
+        elif name in standard_variants and isinstance(
+            standard_variants[name].get("default"), (bool, syaml_bool)
+        ):
+            if isinstance(value, str):
+                value = value.lower() == "true"
 
-        if name in reserved_variants:
-            self._define_variant(
-                name,
-                variant_type=variant_types.experiment,
-                default=value,
-                description=None,
-                values=None,
-            )
-        else:
-            self._define_variant(
-                name,
-                variant_type=variant_types.experiment,
-                default=value,
-                description=None,
-                values=None,
-            )
+        self._define_variant(
+            name,
+            variant_type=variant_types.experiment,
+            default=value,
+            description=None,
+            values=None,
+        )
 
     @invalidates_cache
     def multi_value_variant(self, name: str, value: Any):
@@ -418,12 +429,22 @@ class VariantSet:
                 out_set.update(var.as_definitions())
 
         for name, variant in self.experiment_variants.items():
-            if name in self.default_variants or name in reserved_variants:
+            if (
+                name in self.default_variants
+                or name in reserved_variants
+                or name in standard_variants
+            ):
+                values = None
                 if (
                     name in self.default_variants
                     and name not in reserved_variants
                     and self.default_variants[name].values
                 ):
+                    values = self.default_variants[name].values
+                elif name in standard_variants and standard_variants[name].get("values"):
+                    values = standard_variants[name]["values"]
+
+                if values:
                     val = variant.default
                     if expander and isinstance(val, str) and "{" in val:
                         try:
@@ -433,11 +454,12 @@ class VariantSet:
                     if isinstance(val, str) and "{" in val:
                         pass
                     else:
-                        values = self.default_variants[name].values
                         if callable(values):
                             is_valid = values(val)
-                        else:
+                        elif isinstance(values, (list, tuple, set, Sequence)):
                             is_valid = str(val).lower() in [str(v).lower() for v in values]
+                        else:
+                            is_valid = True
                         if not is_valid:
                             raise RambleVariantError(
                                 f"When defining variant {name} the value {val} is not valid.\n"
@@ -567,20 +589,42 @@ class Variant:
         return self.as_str(n_indent=0)
 
 
-def validate_variant(variant: str):
-    """Check if a variant name is valid or not
+def validate_variant(
+    variant: str,
+    values: Optional[Union[Sequence, Callable[[Any], bool]]] = None,
+    default: Optional[Any] = None,
+):
+    """Check if a variant name and definition are valid or not.
 
     If the input variant name is not valid, this function will raise an
     exception. Otherwise this function will not perform any actions.
 
     Args:
         variant (str): Variant name to test
+        values: Allowed values for the variant
+        default: Default value of the variant
     """
 
     if variant in reserved_variants:
         raise RambleVariantError(
             f"Variant {variant} is invalid, as this name is reserved by ramble"
         )
+
+    if variant in standard_variants:
+        std_info = standard_variants[variant]
+        std_values = std_info.get("values")
+        if (
+            std_values
+            and values is not None
+            and isinstance(std_values, (list, tuple, set, Sequence))
+        ):
+            if isinstance(values, (list, tuple, set, Sequence)):
+                for val in values:
+                    if val not in std_values:
+                        raise RambleVariantError(
+                            f"Variant {variant} is a standard variant and value {val} "
+                            f"is not in standard values {std_values}"
+                        )
 
 
 class RambleVariantError(ramble.error.RambleError):

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -179,6 +179,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         default=True,
         description="Whether to include automatically injected modifiers",
     )
+    variant(
+        namespace.containerized,
+        default=False,
+        description="Whether this experiment is run inside a container",
+    )
 
     license_names: List[str] = []
 
@@ -214,11 +219,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             name=self.keywords.repeat_index,
             default=0,
             description="Index of this experiment, in repeat space",
-        )
-        self.object_variants.default_variant(
-            name=namespace.containerized,
-            default=False,
-            description="Whether this experiment is run inside a container",
         )
 
         self._vars_are_expanded = False
@@ -1073,6 +1073,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if modifiers:
             self.modifiers = modifiers.copy()
         self.build_modifier_instances()
+        self.clear_variant_cache()
 
     def set_tags(self, tags):
         """Set experiment tags for this instance"""
@@ -1657,9 +1658,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 mod_inst.expander.add_no_expand_var(var)
 
         # Define any missing modifier variables
-        self.define_missing_variables()
         if self.modifiers:
             self.clear_variant_cache()
+        self.define_missing_variables()
 
     @property
     def inventory_file(self):
@@ -1831,7 +1832,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         commands = []
         all_cleanups = {}
         for when_set, named_cleanups in self.cleanups.items():
-            if self.expander.satisfies(when_set, self.object_variants):
+            if self.expander.satisfies(when_set, self.experiment_variants()):
                 all_cleanups.update(named_cleanups)
 
         for name, cleanup_props in all_cleanups.items():

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -14,7 +14,7 @@ import ramble.definitions.families
 import ramble.util.class_attributes
 import ramble.variants
 from ramble.expander import ExpanderError
-from ramble.language.shared_language import SharedMeta
+from ramble.language.shared_language import SharedMeta, variant
 from ramble.language.workflow_manager_language import (
     WorkflowManagerMeta,
     workflow_manager_variable,
@@ -36,7 +36,12 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
         "setup",
         "execute",
     ]
-    is_containerized = False
+
+    variant(
+        namespace.containerized,
+        default=False,
+        description="Whether this workflow manager runs in containers",
+    )
 
     workflow_manager_variable(
         "workflow_banner",
@@ -97,15 +102,6 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
         """Set a reference to the associated app_inst"""
         self.app_inst = app_inst
         self.clear_variant_cache()
-
-        if (
-            self.is_containerized
-            and namespace.containerized not in app_inst.variants
-        ):
-            app_inst.object_variants.experiment_variant(
-                namespace.containerized, True
-            )
-            app_inst.clear_variant_cache()
 
     @abc.abstractmethod
     def get_status(self, workspace):

--- a/var/ramble/repos/builtin/base_modifiers/container-base/base_modifier.py
+++ b/var/ramble/repos/builtin/base_modifiers/container-base/base_modifier.py
@@ -23,6 +23,12 @@ class ContainerBase(BasicModifier):
 
     maintainers("douglasjacobsen")
 
+    variant(
+        "containerized",
+        default=True,
+        description="Whether this experiment is run inside a container",
+    )
+
     mode("standard", description="Standard execution mode")
     default_mode("standard")
 

--- a/var/ramble/repos/builtin/workflow_managers/gke-mpi/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/gke-mpi/workflow_manager.py
@@ -24,7 +24,11 @@ class GkeMpi(WorkflowManagerBase):
 
     tags("workflow", "gke", "mpi")
 
-    is_containerized = True
+    variant(
+        "containerized",
+        default=True,
+        description="GKE MPI runs in containers",
+    )
 
     workflow_manager_variable(
         name="job_name",

--- a/var/ramble/repos/builtin/workflow_managers/slurm-pyxis/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm-pyxis/workflow_manager.py
@@ -19,7 +19,11 @@ class SlurmPyxis(SlurmBase):
 
     tags("workflow", "slurm", "pyxis")
 
-    is_containerized = True
+    variant(
+        "containerized",
+        default=True,
+        description="Slurm Pyxis runs in containers",
+    )
 
     workflow_manager_variable(
         name="container_path",


### PR DESCRIPTION
This changes how `validate_variant` works and allows standard variants (eg containerized) to be declared via `variant`