### PR TITLE
Lazy load command dependencies

### DIFF
--- a/lib/ramble/ramble/cmd/clean.py
+++ b/lib/ramble/ramble/cmd/clean.py
@@ -14,7 +14,6 @@ import shutil
 from llnl.util import tty
 
 import ramble.caches
-import ramble.reports
 from ramble.paths import lib_path, var_path
 from ramble.util.logger import logger
 
@@ -92,6 +91,8 @@ def remove_python_caches():
 
 
 def remove_reports_files():
+    import ramble.reports
+
     reports_path = ramble.reports.get_reports_path()
     if reports_path:
 

--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -11,15 +11,8 @@ from typing import Callable, Dict
 
 import llnl.util.filesystem as fs
 
-import ramble.cmd
 import ramble.cmd.common
 import ramble.config
-import ramble.fetch_strategy
-import ramble.filters
-import ramble.pipeline
-import ramble.repository
-import ramble.stage
-import ramble.util.path
 from ramble.cmd.common import arguments
 from ramble.main import RambleCommand
 from ramble.util import json_util
@@ -78,6 +71,10 @@ def deployment_push_setup_parser(subparser):
 
 
 def deployment_push(args):
+    import ramble.cmd
+    import ramble.filters
+    import ramble.pipeline
+
     current_pipeline = ramble.pipeline.pipelines.pushdeployment
     ws = ramble.cmd.require_active_workspace(cmd_name="deployment push")
 
@@ -117,6 +114,12 @@ def deployment_pull_setup_parser(subparser):
 
 
 def deployment_pull(args):
+    import ramble.cmd
+    import ramble.fetch_strategy
+    import ramble.pipeline
+    import ramble.stage
+    import ramble.util.path
+
     def pull_file(src, dest):
         fetcher = ramble.fetch_strategy.URLFetchStrategy(url=src)
         stage_dir = os.path.dirname(dest)

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -12,7 +12,6 @@ import os
 from llnl.util.tty.colify import colified
 
 import ramble.cmd
-import ramble.reports
 import ramble.uploader
 import ramble.util.colors as color
 from ramble.util.logger import logger
@@ -244,6 +243,8 @@ def _print_attr_dict(attr_dict: dict, n_indent=0):
 
 def results_index(args):
     """List attributes in results including FOMs and template variables"""
+    import ramble.reports
+
     results_dict = _load_results(args)
     filtered_experiments = ramble.reports.filter_exp_results(results_dict["experiments"])
     result_index = ramble.reports.generate_result_index(
@@ -259,6 +260,8 @@ def results_index(args):
 
 def results_report(args):
     """Create a report with charts from Ramble experiment results."""
+    import ramble.reports
+
     results_dict = _load_results(args)
 
     if "workspace_name" in results_dict:


### PR DESCRIPTION
The motivation is that certain dependencies from `ramble.reports` are causing the free-threading to be disabled (for 3.14 and up). Dynamically loading the dependencies help with both startup speed, as well as avoiding the free-threading disablement when running with other unrelated commands.