### PR TITLE
Add success_criteria to workspace manage experiments

### DIFF
--- a/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
+++ b/lib/ramble/docs/tutorials/Workspace_manage_experiments_command.rst
@@ -355,6 +355,22 @@ Output:
 Ramble automatically generated 6 distinct experiments representing the cross-product
 of 3 node counts and 2 problem sizes.
 
+-------------------------
+Defining Success Criteria
+-------------------------
+
+You can define custom experiment :ref:`success criteria <success-criteria>` using the ``-s`` (or ``--success-criteria``) flag.
+Criteria are specified in comma-separated key=value format (e.g. ``name=CRITERIA,mode=TYPE,...``):
+
+.. code-block:: console
+
+   $ ramble -D manage-workspace workspace manage experiments hostname \
+        --wf local \
+        -s name=check_output,mode=string,match="Host.*" \
+        --overwrite
+
+If either the ``key`` or ``value`` contains a comma, equals sign, or space, you must quote the key/value.
+
 ---------------------------------------
 Previewing Configurations with Dry Runs
 ---------------------------------------

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1592,6 +1592,15 @@ def workspace_manage_experiments_setup_parser(subparser):
         "which is likely to cause validation errors",
     )
 
+    subparser.add_argument(
+        "--success-criteria",
+        "-s",
+        dest="success_criteria",
+        action="append",
+        help="success criteria for the experiments, in the format "
+        "'name=CRITERIA,mode=TYPE,...' May be specified multiple times",
+    )
+
 
 def workspace_manage_experiments(args):
     """Perform experiment management"""
@@ -1632,6 +1641,10 @@ def workspace_manage_experiments(args):
     if args.matrix:
         matrix = args.matrix
 
+    success_criteria = []
+    if args.success_criteria:
+        success_criteria = args.success_criteria
+
     ws.add_experiments(
         args.application,
         args.workload_name_variable,
@@ -1647,6 +1660,7 @@ def workspace_manage_experiments(args):
         zips,
         matrix,
         args.overwrite,
+        success_criteria,
     )
 
     if ws.dry_run:

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -3530,3 +3530,202 @@ def test_workspace_manage_filter_groups_rm_alias(workspace_name):
         )
         out = workspace("manage", "filter-groups", "list", global_args=global_args)
         assert "test-group" not in out
+
+
+def test_manage_experiments_single_success_criterion(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-s",
+            "name=crit1,mode=string,match=SUCCESS",
+            global_args=global_args,
+        )
+
+        with open(ws.config_file_path, encoding="utf-8") as f:
+            data = f.read()
+            assert "success_criteria:" in data
+            assert "name: crit1" in data
+            assert "mode: string" in data
+            assert "match: SUCCESS" in data
+
+
+def test_manage_experiments_multiple_success_criteria(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-s",
+            "name=c1,mode=string,match=PASS",
+            "-s",
+            "name=c2,mode=string,anti_match=FAIL",
+            global_args=global_args,
+        )
+
+        with open(ws.config_file_path, encoding="utf-8") as f:
+            data = f.read()
+            assert "success_criteria:" in data
+            assert "name: c1" in data
+            assert "match: PASS" in data
+            assert "name: c2" in data
+            assert "anti_match: FAIL" in data
+
+
+def test_manage_experiments_fom_success_criterion(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-s",
+            'name=fom_c,mode=fom_comparison,fom_name=my_fom,formula="{value} > 5"',
+            global_args=global_args,
+        )
+
+        with open(ws.config_file_path, encoding="utf-8") as f:
+            data = f.read()
+            assert "success_criteria:" in data
+            assert "name: fom_c" in data
+            assert "mode: fom_comparison" in data
+            assert "fom_name: my_fom" in data
+            assert "formula:" in data
+
+
+@pytest.mark.parametrize(
+    "crit_str,err_msg",
+    [
+        ("mode=string,match=SUCCESS", "requires a 'name' attribute"),
+        ("name=c1,match=SUCCESS", "requires a 'mode' attribute"),
+        ("name=c1,mode=invalid_mode", "mode 'invalid_mode' is invalid"),
+        ("name=c1,mode=string", "requires 'match' or 'anti_match'"),
+        (
+            "name=c1,mode=string,match=M,anti_match=A",
+            "requires exactly one of 'match' or 'anti_match'",
+        ),
+        ("name=c1,mode=fom_comparison,fom_name=my_fom", "requires 'fom_name' and 'formula'"),
+        ("name=c1,invalid_attribute", "Invalid success_criteria attribute definition"),
+    ],
+)
+def test_manage_experiments_invalid_success_criteria(workspace_name, crit_str, err_msg):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name):
+        with pytest.raises(RambleCommandError, match=err_msg):
+            workspace(
+                "manage",
+                "experiments",
+                "basic",
+                "--wf",
+                "test_wl",
+                "-v",
+                "n_ranks=1",
+                "-v",
+                "n_nodes=1",
+                "-s",
+                crit_str,
+                global_args=global_args,
+            )
+
+
+def test_manage_experiments_duplicate_success_criteria(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name):
+        with pytest.raises(RambleCommandError, match="Duplicate success criteria name 'c1'"):
+            workspace(
+                "manage",
+                "experiments",
+                "basic",
+                "--wf",
+                "test_wl",
+                "-v",
+                "n_ranks=1",
+                "-v",
+                "n_nodes=1",
+                "-s",
+                "name=c1,mode=string,match=PASS",
+                "-s",
+                "name=c1,mode=string,match=PASS2",
+                global_args=global_args,
+            )
+
+
+def test_manage_experiments_success_criteria_special_characters(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-s",
+            (
+                "name=c_val_quotes,mode=fom_comparison,fom_name=my_fom,"
+                'formula="{value} > 5, {value} < 100"'
+            ),
+            "-s",
+            (
+                "name=c_single_quotes,mode=fom_comparison,fom_name=my_fom,"
+                "formula='{value} > 5, {value} < 100'"
+            ),
+            "-s",
+            (
+                "name=c_attr_quotes,mode=fom_comparison,fom_name=my_fom,"
+                '"formula={value} > 5, {value} < 100"'
+            ),
+            "-s",
+            (
+                "name=c_escaped,mode=fom_comparison,fom_name=my_fom,"
+                'formula=\\"{value} > 5, {value} < 100\\"'
+            ),
+            "-s",
+            'name=c_equals,mode=string,match="status=OK"',
+            "-s",
+            "name=c_nested,mode=string,match=\"status='OK, DONE'\"",
+            global_args=global_args,
+        )
+
+        with open(ws.config_file_path, encoding="utf-8") as f:
+            data = f.read()
+            assert "success_criteria:" in data
+            assert "name: c_val_quotes" in data
+            assert "name: c_single_quotes" in data
+            assert "name: c_attr_quotes" in data
+            assert "name: c_escaped" in data
+            assert "{value} > 5, {value} < 100" in data
+            assert "name: c_equals" in data
+            assert "status=OK" in data
+            assert "name: c_nested" in data
+            assert "status='OK, DONE'" in data

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
@@ -27,38 +27,36 @@ workspace = RambleCommand("workspace")
 ramble_on = RambleCommand("on")
 
 
-def test_success_criteria_precedence(mock_applications, make_workspace_from_config):
+def test_success_criteria_precedence(mock_applications, workspace_name):
     """
     Tests that YAML success_criteria takes precedence over
     object-defined criteria
     """
-    # TODO: Update once success_criteria has manage experiments command
-    test_config = """
-ramble:
-  variables:
-    processes_per_node: '1'
-    n_threads: '1'
-  applications:
-    success-criteria-conflicts:
-      workloads:
-        success_str_wl:
-          experiments:
-            pass-experiment:
-              variables:
-                n_nodes: 1
-              success_criteria:
-              - name: test_success
-                mode: string
-                match: 'SUCCESS'
-  software:
-    packages: {}
-    environments: {}
-"""
-    ws, ws_name = make_workspace_from_config(test_config)
+    global_args = ["-w", workspace_name]
 
-    workspace("setup", global_args=["-w", ws_name])
-    ramble_on(global_args=["-w", ws_name])
-    workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", ws_name])
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "success-criteria-conflicts",
+            "-e",
+            "pass-experiment",
+            "--wf",
+            "success_str_wl",
+            "-v",
+            "processes_per_node=1",
+            "-v",
+            "n_threads=1",
+            "-v",
+            "n_nodes=1",
+            "-s",
+            "name=test_success,mode=string,match=SUCCESS",
+            global_args=global_args,
+        )
+
+    workspace("setup", global_args=global_args)
+    ramble_on(global_args=global_args)
+    workspace("analyze", "-f", "text", "json", "yaml", global_args=global_args)
 
     for ext in ["txt", "json", "yaml"]:
         assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -34,6 +34,7 @@ import ramble.schema.merged
 import ramble.schema.workspace
 import ramble.software_environments
 import ramble.spec
+import ramble.success_criteria
 import ramble.util.hashing
 import ramble.util.install_cache
 import ramble.util.lock as lk
@@ -1177,6 +1178,7 @@ ramble:
         zips=None,
         matrix=None,
         overwrite=False,
+        success_criteria=None,
     ):
         """Add new experiments to this workspace
 
@@ -1206,10 +1208,15 @@ ramble:
                           experiment in the format of var1,var2,var3.
             overwrite (bool): Whether to overwrite existing definitions that
                               collide with new definitions or not.
+            success_criteria (list(str) | None): List of success criteria definitions to set
+                                                 in the generated experiments.
         """
 
         if zips is None:
             zips = []
+
+        if success_criteria is None:
+            success_criteria = []
 
         def yaml_add_comment_before_key(
             base, key, comment, column=None, clear=False, start_char="#"
@@ -1274,6 +1281,116 @@ ramble:
                     )
             return def_dict
 
+        def _split_csv_attributes(definition):
+            pairs = []
+            current = []
+            in_quote = None
+            i = 0
+            n = len(definition)
+
+            while i < n:
+                char = definition[i]
+                if char == "\\" and i + 1 < n and definition[i + 1] in ("'", '"'):
+                    char = definition[i + 1]
+                    i += 1
+
+                if in_quote:
+                    current.append(char)
+                    if char == in_quote:
+                        in_quote = None
+                elif char in ("'", '"'):
+                    in_quote = char
+                    current.append(char)
+                elif char == ",":
+                    pairs.append("".join(current))
+                    current = []
+                else:
+                    current.append(char)
+                i += 1
+
+            if current:
+                pairs.append("".join(current))
+
+            return pairs
+
+        def process_success_criteria_definitions(definitions):
+            criteria_list = []
+            seen_names = set()
+            valid_modes = ramble.success_criteria.SuccessCriteria._valid_modes
+            for definition in definitions:
+                scrit_dict = syaml.syaml_dict()
+                try:
+                    pairs = _split_csv_attributes(definition)
+                except Exception as e:
+                    logger.die(f"Failed to parse success_criteria definition '{definition}': {e}")
+
+                for pair in pairs:
+                    pair = strip_quotes(pair.strip())
+                    if not pair:
+                        continue
+                    m = _DEF_REGEX.search(pair)
+                    if m:
+                        key = pair[0 : m.start()].strip()
+                        val = list_str_to_list(pair[m.end() :].strip())
+                        if isinstance(val, str):
+                            val = strip_quotes(val)
+                            if (val.startswith('\\"') and val.endswith('\\"')) or (
+                                val.startswith("\\'") and val.endswith("\\'")
+                            ):
+                                val = strip_quotes(val[1:-1])
+                        scrit_dict[key] = val
+                    else:
+                        logger.die(
+                            f"Invalid success_criteria attribute definition: '{pair}' "
+                            f"in '{definition}'. Accepted form is 'key=value'"
+                        )
+
+                if "name" not in scrit_dict:
+                    logger.die(
+                        f"Success criteria definition '{definition}' requires a 'name' attribute."
+                    )
+                if "mode" not in scrit_dict:
+                    logger.die(
+                        f"Success criteria definition '{definition}' requires a 'mode' attribute."
+                    )
+
+                scrit_name = scrit_dict["name"]
+                if scrit_name in seen_names:
+                    logger.die(
+                        f"Duplicate success criteria name '{scrit_name}' found in definitions."
+                    )
+                seen_names.add(scrit_name)
+
+                mode = scrit_dict["mode"]
+                if mode not in valid_modes:
+                    logger.die(
+                        f"Success criteria mode '{mode}' is invalid. "
+                        f"Valid modes are: {valid_modes}"
+                    )
+
+                if mode == "string":
+                    has_match = "match" in scrit_dict
+                    has_anti_match = "anti_match" in scrit_dict
+                    if not has_match and not has_anti_match:
+                        logger.die(
+                            f"Success criteria '{scrit_name}' with mode='string' "
+                            "requires 'match' or 'anti_match'."
+                        )
+                    if has_match and has_anti_match:
+                        logger.die(
+                            f"Success criteria '{scrit_name}' with mode='string' "
+                            "requires exactly one of 'match' or 'anti_match'."
+                        )
+                elif mode == "fom_comparison":
+                    if "formula" not in scrit_dict or "fom_name" not in scrit_dict:
+                        logger.die(
+                            f"Success criteria '{scrit_name}' with mode='fom_comparison' "
+                            "requires 'fom_name' and 'formula'."
+                        )
+
+                criteria_list.append(scrit_dict)
+            return criteria_list
+
         edited = False
 
         workspace_vars = ramble.config.get(namespace.variables)
@@ -1289,6 +1406,7 @@ ramble:
 
         exp_context.variables = process_definitions(variable_definitions, def_type="variable")
         exp_context.variants = process_definitions(variant_definitions, def_type="variant")
+        exp_context.success_criteria = process_success_criteria_definitions(success_criteria)
 
         # TODO: Deprecate / remove in favor of explicit variant definitions
         if package_manager:
@@ -1455,6 +1573,10 @@ ramble:
             if exp_context.matrices:
                 if namespace.matrix not in exp_dict:
                     exp_dict[namespace.matrix] = exp_context.matrices.copy()[0]
+
+            if exp_context.success_criteria:
+                if namespace.success not in exp_dict:
+                    exp_dict[namespace.success] = exp_context.success_criteria.copy()
 
         self.dry_run = is_dry_run
         if edited and not self.dry_run:

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -749,7 +749,7 @@ _ramble_workspace_remove() {
 _ramble_workspace_generate_config() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --variant-definition -V --experiment-name -e --package-manager -p --workflow-manager --wm --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m --default-variable-value"
+        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --variant-definition -V --experiment-name -e --package-manager -p --workflow-manager --wm --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m --default-variable-value --success-criteria -s"
     else
         _all_applications
     fi
@@ -767,7 +767,7 @@ _ramble_workspace_manage() {
 _ramble_workspace_manage_experiments() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --variant-definition -V --experiment-name -e --package-manager -p --workflow-manager --wm --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m --default-variable-value"
+        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --variant-definition -V --experiment-name -e --package-manager -p --workflow-manager --wm --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m --default-variable-value --success-criteria -s"
     else
         _all_applications
     fi


### PR DESCRIPTION
This PR adds functionality for specifying `success_criteria` using `workspace manage experiments` using a comma separated key-value pair format - `name=:
- New command line argument added `-s / --success-criteria`
- Supports `string` and `fom_comparison` modes:
  - String: `-s name=string_mode,mode=string,match=SUCCESS`
  - FOM Comparison: `-s name=fom_mode,mode=fom_comparison,fom_name=my_fom,formula="{value} > 5"`
- Updates existing `success_criteria` unit test that required specifying YAML, to now use `manage experiments`
- Adds new unit tests for new code paths added

Something to note is that because this needs to parse a comma separated kv-pair formatted string, there's a new internal lexical parser, `_split_csv_attributes`, created to do this. Initially I had used a simple `re.split` on commas but realized that FOM comparisons can have commas in them - e.g., `{value} > 5, {value} < 90` - and that would incorrectly split. Then I attempted to use the builtin `csv` module, but that wants values captured in quotes so a user would have to use something like `name=fom_mode,mode=fom_comparison,fom_name=my_fom,"formula={value} > 5, {value} < 90"`, but I thought most users wouldn't know to follow strict CSV formatting and would want to do something like `name=fom_mode,mode=fom_comparison,fom_name=my_fom,formula="{value} > 5, {value} < 90"`. Since `shlex` is used elsewhere I explored that, but that assumes shell parsing by default and so something like `name=string_mode,mode=string,match="#SUCCESS"` would get mangled. I also thought users may want to use nested quotes like `'name=string_mode,mode=string,match="#SUCCESS"'` or even nested escaped quotes like `"name=string_mode,mode=string,match=\\"#SUCCESS\\""`and so rather than try to devise some convoluted and dense regex, this parser was created to handle all of this cleanly and readably.