### PR TITLE
fix mistleading activate code when called inside a script

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -167,7 +167,7 @@ def workspace_activate(args):
         ramble.cmd.common.shell_init_instructions(
             "ramble workspace activate", "    eval `ramble workspace activate {sh_arg} [...]`"
         )
-        return 1
+        sys.exit(1)
 
     workspace_name_or_dir = args.activate_workspace or args.dir
 
@@ -256,7 +256,7 @@ def workspace_deactivate(args):
             "ramble workspace deactivate",
             "    eval `ramble workspace deactivate {sh_arg}`",
         )
-        return 1
+        sys.exit(1)
 
     # Error out when -w, -W, -D flags are given, cause they are ambiguous.
     if args.workspace or args.no_workspace or args.workspace_dir:

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -133,8 +133,9 @@ def test_workspace_create_links(mutable_mock_workspace_path, tmpdir):
 
 def test_workspace_activate_fails(mutable_mock_workspace_path):
     workspace("create", "foo")
-    out = workspace("activate", "foo")
+    out = workspace("activate", "foo", fail_on_error=False)
     assert "To set up shell support" in out
+    assert workspace.returncode == 1
 
 
 def test_workspace_activate_prompt(workspace_name, monkeypatch):
@@ -230,6 +231,7 @@ def test_workspace_deactivate(workspace_name, working_env):
     # Test deactivation fails without shell args
     output = workspace("deactivate", fail_on_error=False)
     assert "To set up shell support" in output
+    assert workspace.returncode == 1
 
     # Test deactivation fails with ambiguous flags
     ramble.workspace.activate(ws)


### PR DESCRIPTION
Most ramble commands rely on calling sys.exit in a failure case, and we do not actually propagate returned codes. This lead to a situation where you can activate a workspace in a script and get a misleading return code

```
  $ bin/ramble workspace activate aaaa
    ==> Error: `ramble workspace activate` requires ramble's shell support.
    ...
    $ echo $?
    0
```