### PR TITLE
Update to use 2nd gen repo connector config

### DIFF
--- a/share/ramble/cloud-build/terraform/triggers/codecov.tf
+++ b/share/ramble/cloud-build/terraform/triggers/codecov.tf
@@ -13,7 +13,7 @@ resource "google_cloudbuild_trigger" "codecov_pr" {
   description = "Run unit tests and linting on Ramble pull requests with Codecov upload"
 
   repository_event_config {
-    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/RambleCI-SA-W1/repositories/${var.github_owner}-${var.github_repo}"
+    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/Ramble-SAW1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
@@ -50,7 +50,7 @@ resource "google_cloudbuild_trigger" "codecov_push" {
   description = "Collect coverage information on develop or main pushes"
 
   repository_event_config {
-    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/RambleCI-SA-W1/repositories/${var.github_owner}-${var.github_repo}"
+    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/Ramble-SAW1/repositories/${var.github_owner}-${var.github_repo}"
     push {
       branch = "(?:main|develop)"
     }

--- a/share/ramble/cloud-build/terraform/triggers/image_builds.tf
+++ b/share/ramble/cloud-build/terraform/triggers/image_builds.tf
@@ -5,9 +5,8 @@ resource "google_cloudbuild_trigger" "image_builders" {
   name        = "ramble-image-builder-${each.value.base}${replace(each.value.base_ver, ".", "-")}-py${replace(each.value.python, ".", "-")}-spack${replace(each.value.spack, ".", "-")}"
   description = "Build Ramble cloud build image for ${each.value.base} ${each.value.base_ver} with Python ${each.value.python} and Spack ${each.value.spack}"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     push {
       branch = "^develop$"
     }

--- a/share/ramble/cloud-build/terraform/triggers/perf_tests.tf
+++ b/share/ramble/cloud-build/terraform/triggers/perf_tests.tf
@@ -18,9 +18,8 @@ resource "google_cloudbuild_trigger" "perf_test_pr" {
   name        = "PerfTest-PR-${local.perf_test_img.base}${local.perf_test_img.base_ver}-${replace(local.perf_test_img.spack, ".", "-")}spack-${replace(local.perf_test_img.python, ".", "-")}python"
   description = "Ramble perf tests for PR builds"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
@@ -59,9 +58,8 @@ resource "google_cloudbuild_trigger" "perf_test_push" {
   name        = "PerfTest-Push-${local.perf_test_img.base}${local.perf_test_img.base_ver}-${replace(local.perf_test_img.spack, ".", "-")}spack-${replace(local.perf_test_img.python, ".", "-")}python"
   description = "Continuous monitoring of Ramble performance for develop push"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     push {
       branch = "^develop$"
     }

--- a/share/ramble/cloud-build/terraform/triggers/pr_doc_build.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_doc_build.tf
@@ -7,9 +7,8 @@ resource "google_cloudbuild_trigger" "pr_doc_build_tests" {
   name        = "PR-Doc-Build-Tests"
   description = "A presubmit check for building Ramble documentation"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
@@ -3,9 +3,8 @@ resource "google_cloudbuild_trigger" "pr_image_build_tests_debian" {
   name        = "PR-Image-Build-Tests-Debian"
   description = "A presubmit check for building Debian image used by other cloud build triggers"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
@@ -34,9 +33,8 @@ resource "google_cloudbuild_trigger" "pr_image_build_tests_rocky" {
   name        = "PR-Image-Build-Tests-Rocky"
   description = "A presubmit check for building Rocky image used by other cloud build triggers"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/share/ramble/cloud-build/terraform/triggers/pr_software_conflicts.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_software_conflicts.tf
@@ -7,9 +7,8 @@ resource "google_cloudbuild_trigger" "pr_software_conflicts" {
   name        = "PR-Software-Conflicts-${local.pr_software_conflicts_img.base}${local.pr_software_conflicts_img.base_ver}-${replace(local.pr_software_conflicts_img.spack, ".", "-")}spack-${replace(local.pr_software_conflicts_img.python, ".", "-")}python"
   description = "Check for conflicts in application definitions on Ramble pull requests"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/share/ramble/cloud-build/terraform/triggers/pr_style.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_style.tf
@@ -7,9 +7,8 @@ resource "google_cloudbuild_trigger" "pr_style" {
   name        = "PR-Style-${local.pr_style_img.base}${local.pr_style_img.base_ver}-${replace(local.pr_style_img.spack, ".", "-")}spack-${replace(local.pr_style_img.python, ".", "-")}python"
   description = "Run linting on Ramble pull requests"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
@@ -17,7 +17,7 @@ resource "google_cloudbuild_trigger" "pr_unit_tests" {
   description = "Run unit tests and linting on Ramble pull requests"
 
   repository_event_config {
-    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/RambleCI-SA-W1/repositories/${var.github_owner}-${var.github_repo}"
+    repository = "projects/${var.project_id}/locations/${google_cloudbuild_worker_pool.unit_test_pool.location}/connections/Ramble-SAW1/repositories/${var.github_owner}-${var.github_repo}"
     pull_request {
       branch          = "(?:main|develop)"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/share/ramble/cloud-build/terraform/triggers/terraform_apply.tf
+++ b/share/ramble/cloud-build/terraform/triggers/terraform_apply.tf
@@ -3,9 +3,8 @@ resource "google_cloudbuild_trigger" "terraform_apply" {
   name        = "ramble-terraform-apply"
   description = "Automatically apply Cloud Build Triggers Terraform configuration when pushed to develop branch"
 
-  github {
-    owner = var.github_owner
-    name  = var.github_repo
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/Ramble-USC1/repositories/${var.github_owner}-${var.github_repo}"
     push {
       branch = "^develop$"
     }

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -103,14 +103,17 @@ if [[ "$PUSH_CODECOV" ]]; then
   
   echo "Processing codecov upload for commit $COMMIT_SHA"
 
-  UPLOAD_ARGS="-C $COMMIT_SHA"
+  UPLOAD_ARGS="-C $COMMIT_SHA --git-service github --slug Ramble-Project/ramble"
   if [[ -n "$PR_NUMBER" ]]; then
     UPLOAD_ARGS="$UPLOAD_ARGS --pr $PR_NUMBER"
+  else
+    UPLOAD_ARGS="$UPLOAD_ARGS -B $TARGET_BRANCH"
   fi
   if [[ -n "$MERGE_BASE_SHA" ]]; then
     echo "Picking PR base: $MERGE_BASE_SHA"
     if [[ -n "$PR_NUMBER" ]]; then
-      codecovcli pr-base-picking --base-sha $MERGE_BASE_SHA --pr $PR_NUMBER --slug "Ramble-Project/ramble"
+      codecovcli pr-base-picking --base-sha $MERGE_BASE_SHA --pr $PR_NUMBER --slug "Ramble-Project/ramble" --service github
+      UPLOAD_ARGS="$UPLOAD_ARGS --parent-sha $MERGE_BASE_SHA"
     else
       echo "Skipping pr-base-picking: PR_NUMBER not set"
     fi


### PR DESCRIPTION
As part of the migration, these connectors are now the 2nd gen. Updating the terraform config to match with what's used in the project.