### PR TITLE
fix ctrl+c signal termination signal

### DIFF
--- a/lib/ramble/ramble/cmd/create.py
+++ b/lib/ramble/ramble/cmd/create.py
@@ -7,10 +7,13 @@
 # except according to those terms.
 
 
+import signal
+
 import ramble.creator
 import ramble.repository
 import ramble.spec
 import ramble.util.naming as nm
+from ramble.main import POSIX_SIGNAL_EXIT_OFFSET
 from ramble.util.logger import logger
 
 description = "create a new application, modifier, or other object definition"
@@ -234,7 +237,7 @@ def create(parser, args):
             obj_type, name, repo, base, maintainers, tags = run_interactive_wizard()
         except KeyboardInterrupt:
             print("\n\n[ABORTED] Object creation cancelled.")
-            return 1
+            return POSIX_SIGNAL_EXIT_OFFSET + signal.SIGINT.value
 
     try:
         file_path, repo_namespace = ramble.creator.create_object(

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -89,6 +89,9 @@ required_command_properties = ["level", "section", "description"]
 ramble_working_dir = None
 ramble_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
 
+#: Standard POSIX offset for exit codes from signal termination (128 + signal)
+POSIX_SIGNAL_EXIT_OFFSET = 128
+
 
 def set_working_dir():
     """Change the working directory to getcwd, or ramble prefix if no cwd."""
@@ -1100,7 +1103,7 @@ def main(argv=None):
             raise
         sys.stderr.write("\n")
         logger.error("Keyboard interrupt.")
-        return signal.SIGINT.value
+        return POSIX_SIGNAL_EXIT_OFFSET + signal.SIGINT.value
 
     except SystemExit as e:
         if ramble.config.get("config:debug"):

--- a/lib/ramble/ramble/test/cmd/create.py
+++ b/lib/ramble/ramble/test/cmd/create.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import signal
 import sys
 
 import pytest
@@ -320,6 +321,7 @@ def test_create_interactive_wizard_validation_and_abort(mutable_config, tmpdir, 
     # create_cmd should exit gracefully without raising exception
     out = create_cmd("-i", fail_on_error=False)
     assert "[ABORTED] Object creation cancelled" in out
+    assert create_cmd.returncode == ramble.main.POSIX_SIGNAL_EXIT_OFFSET + signal.SIGINT.value
 
 
 @pytest.mark.parametrize(

--- a/lib/ramble/ramble/test/cmd/main.py
+++ b/lib/ramble/ramble/test/cmd/main.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import signal
+
 import pytest
 
 import ramble.main
@@ -65,3 +67,14 @@ def test_global_config_scope(tmpdir, capsys):
     captured = capsys.readouterr()
     assert ret == 0
     assert "A flexible benchmark experiment manager" in captured.out
+
+
+def test_keyboard_interrupt_exit_code(monkeypatch, capsys):
+    def mock_invoke(*args, **kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(ramble.main, "_invoke_command", mock_invoke)
+    ret = ramble.main.main(argv=["workspace", "list"])
+    captured = capsys.readouterr()
+    assert ret == ramble.main.POSIX_SIGNAL_EXIT_OFFSET + signal.SIGINT.value
+    assert "Keyboard interrupt." in captured.err


### PR DESCRIPTION
This lets us adhere to the standard POSIX convention (128 + N) for signal termination