### PR TITLE
Specify codecov comment format

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,3 +8,9 @@ coverage:
     patch:
       default:
         target: 90%
+comment:
+  layout: "header, diff, flags, condensed_files, footer"
+  behavior: default
+  require_changes: false
+  hide_project_coverage: false
+

--- a/share/ramble/cloud-build/terraform/triggers/codecov.tf
+++ b/share/ramble/cloud-build/terraform/triggers/codecov.tf
@@ -26,6 +26,7 @@ resource "google_cloudbuild_trigger" "codecov_pr" {
     local.core_source_files,
     local.dependency_and_config_files,
     [
+      ".github/codecov.yml",
       "share/ramble/cloud-build/**",
       "share/ramble/qa/**"
     ]


### PR DESCRIPTION
This is an attempt to restore the previous (before repo migration) codecov comment format.